### PR TITLE
Import & adapt service tests from `payavel/checkout`.

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,6 +8,9 @@
         <testsuite name="Feature">
             <directory suffix="Test.php">./tests/Feature</directory>
         </testsuite>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>
     </testsuites>
     <coverage>
         <include>

--- a/src/DataTransferObjects/Merchant.php
+++ b/src/DataTransferObjects/Merchant.php
@@ -20,31 +20,11 @@ class Merchant implements Merchantable
      */
     public Serviceable $service;
 
-    /**
-     * Collection of providers this merchant is supported by.
-     *
-     * @var \Payavel\Serviceable\Contracts\Serviceable $service
-     * @var \Illuminate\Support\Collection
-     */
-    public $providers;
-
     public function __construct(Serviceable $service, array $data)
     {
         $this->service = $service;
 
         $this->attributes = $data;
-
-        $this->providers = (new Collection($data['providers'] ?? []))->map(function ($provider, $key) {
-            if (is_array($provider)) {
-                return array_merge(
-                    ['id' => $key],
-                    $this->config($this->service->getId(), 'providers.' . $key),
-                    $provider
-                );
-            }
-
-            return array_merge(['id' => $provider], $this->config($this->service->getId(), 'providers.' . $provider));
-        });
     }
 
     /**
@@ -75,5 +55,25 @@ class Merchant implements Merchantable
     public function getService()
     {
         return $this->service;
+    }
+
+    public function getProviders()
+    {
+        if (! isset($this->providers)) {
+            $this->attributes['providers'] = (new Collection($this->config($this->service->getId(), 'merchants.' . $this->attributes['id'] . '.providers', [])))
+                ->map(function ($provider, $key) {
+                    if (is_array($provider)) {
+                        return array_merge(
+                            ['id' => $key],
+                            $this->config($this->service->getId(), 'providers.' . $key),
+                            $provider
+                        );
+                    }
+
+                    return array_merge(['id' => $provider], $this->config($this->service->getId(), 'providers.' . $provider));
+                });
+        }
+
+        return $this->attributes['providers'];
     }
 }

--- a/tests/Services/Mock/Contracts/MockRequestor.php
+++ b/tests/Services/Mock/Contracts/MockRequestor.php
@@ -4,9 +4,5 @@ namespace Payavel\Serviceable\Tests\Services\Mock\Contracts;
 
 interface MockRequestor
 {
-    public function getProvider();
-
-    public function getMerchant();
-
     public function getIdentity();
 }

--- a/tests/Services/Mock/Contracts/MockRequestor.php
+++ b/tests/Services/Mock/Contracts/MockRequestor.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Payavel\Serviceable\Tests\Services\Mock\Contracts;
+
+interface MockRequestor
+{
+    public function getProvider();
+
+    public function getMerchant();
+
+    public function getIdentity();
+}

--- a/tests/Services/Mock/Contracts/MockResponder.php
+++ b/tests/Services/Mock/Contracts/MockResponder.php
@@ -4,9 +4,5 @@ namespace Payavel\Serviceable\Tests\Services\Mock\Contracts;
 
 interface MockResponder
 {
-    public function getProviderResponse();
-
-    public function getMerchantResponse();
-
     public function getIdentityResponse();
 }

--- a/tests/Services/Mock/Contracts/MockResponder.php
+++ b/tests/Services/Mock/Contracts/MockResponder.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Payavel\Serviceable\Tests\Services\Mock\Contracts;
+
+interface MockResponder
+{
+    public function getProviderResponse();
+
+    public function getMerchantResponse();
+
+    public function getIdentityResponse();
+}

--- a/tests/Services/Mock/FakeMockRequest.php
+++ b/tests/Services/Mock/FakeMockRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Payavel\Serviceable\Tests\Services\Mock;
+
+use Payavel\Serviceable\ServiceRequest;
+use Payavel\Serviceable\Tests\Services\Mock\Contracts\MockRequestor;
+
+class FakeMockRequest extends ServiceRequest implements MockRequestor
+{
+
+    public function getProvider()
+    {
+        return new FakeMockResponse([]);
+    }
+
+    public function getMerchant()
+    {
+        return new FakeMockResponse([]);
+    }
+
+    public function getIdentity()
+    {
+        return new FakeMockResponse([]);
+    }
+}

--- a/tests/Services/Mock/FakeMockRequest.php
+++ b/tests/Services/Mock/FakeMockRequest.php
@@ -7,17 +7,6 @@ use Payavel\Serviceable\Tests\Services\Mock\Contracts\MockRequestor;
 
 class FakeMockRequest extends ServiceRequest implements MockRequestor
 {
-
-    public function getProvider()
-    {
-        return new FakeMockResponse([]);
-    }
-
-    public function getMerchant()
-    {
-        return new FakeMockResponse([]);
-    }
-
     public function getIdentity()
     {
         return new FakeMockResponse([]);

--- a/tests/Services/Mock/FakeMockResponse.php
+++ b/tests/Services/Mock/FakeMockResponse.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Payavel\Serviceable\Tests\Services\Mock;
+
+use Payavel\Serviceable\ServiceResponse;
+use Payavel\Serviceable\Tests\Services\Mock\Contracts\MockResponder;
+
+class FakeMockResponse extends ServiceResponse implements MockResponder
+{
+
+    /**
+     * @inheritDoc
+     */
+    public function getStatusCode()
+    {
+        return 200;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getStatus()
+    {
+        return 'Success';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getMessage()
+    {
+        return 'All good for now!';
+    }
+
+    public function getProviderResponse()
+    {
+        return $this->provider;
+    }
+
+    public function getMerchantResponse()
+    {
+        return $this->merchant;
+    }
+
+    public function getIdentityResponse()
+    {
+        return 'Fake';
+    }
+}

--- a/tests/Services/Mock/FakeMockResponse.php
+++ b/tests/Services/Mock/FakeMockResponse.php
@@ -32,16 +32,6 @@ class FakeMockResponse extends ServiceResponse implements MockResponder
         return 'All good for now!';
     }
 
-    public function getProviderResponse()
-    {
-        return $this->provider;
-    }
-
-    public function getMerchantResponse()
-    {
-        return $this->merchant;
-    }
-
     public function getIdentityResponse()
     {
         return 'Fake';

--- a/tests/Services/Mock/TestMockRequest.php
+++ b/tests/Services/Mock/TestMockRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Payavel\Serviceable\Tests\Services\Mock;
+
+use Payavel\Serviceable\ServiceRequest;
+use Payavel\Serviceable\Tests\Services\Mock\Contracts\MockRequestor;
+
+class TestMockRequest extends ServiceRequest implements MockRequestor
+{
+    public function getProvider()
+    {
+        return new TestMockResponse([]);
+    }
+
+    public function getMerchant()
+    {
+        return new TestMockResponse([]);
+    }
+
+    public function getIdentity()
+    {
+        return new TestMockResponse([]);
+    }
+}

--- a/tests/Services/Mock/TestMockRequest.php
+++ b/tests/Services/Mock/TestMockRequest.php
@@ -7,16 +7,6 @@ use Payavel\Serviceable\Tests\Services\Mock\Contracts\MockRequestor;
 
 class TestMockRequest extends ServiceRequest implements MockRequestor
 {
-    public function getProvider()
-    {
-        return new TestMockResponse([]);
-    }
-
-    public function getMerchant()
-    {
-        return new TestMockResponse([]);
-    }
-
     public function getIdentity()
     {
         return new TestMockResponse([]);

--- a/tests/Services/Mock/TestMockResponse.php
+++ b/tests/Services/Mock/TestMockResponse.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Payavel\Serviceable\Tests\Services\Mock;
+
+use Payavel\Serviceable\ServiceResponse;
+use Payavel\Serviceable\Tests\Services\Mock\Contracts\MockResponder;
+
+class TestMockResponse extends ServiceResponse implements MockResponder
+{
+
+    /**
+     * @inheritDoc
+     */
+    public function getStatusCode()
+    {
+        return 200;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getStatus()
+    {
+        return 'Success';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getMessage()
+    {
+        return 'All good for now!';
+    }
+
+    public function getProviderResponse()
+    {
+        return $this->provider;
+    }
+
+    public function getMerchantResponse()
+    {
+        return $this->merchant;
+    }
+
+    public function getIdentityResponse()
+    {
+        return 'Real';
+    }
+}

--- a/tests/Services/Mock/TestMockResponse.php
+++ b/tests/Services/Mock/TestMockResponse.php
@@ -32,16 +32,6 @@ class TestMockResponse extends ServiceResponse implements MockResponder
         return 'All good for now!';
     }
 
-    public function getProviderResponse()
-    {
-        return $this->provider;
-    }
-
-    public function getMerchantResponse()
-    {
-        return $this->merchant;
-    }
-
     public function getIdentityResponse()
     {
         return 'Real';

--- a/tests/Traits/CreateServiceables.php
+++ b/tests/Traits/CreateServiceables.php
@@ -4,6 +4,8 @@ namespace Payavel\Serviceable\Tests\Traits;
 
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
+use Payavel\Serviceable\Contracts\Merchantable;
+use Payavel\Serviceable\Contracts\Providable;
 use Payavel\Serviceable\DataTransferObjects\Merchant as MerchantDto;
 use Payavel\Serviceable\DataTransferObjects\Provider as ProviderDto;
 use Payavel\Serviceable\DataTransferObjects\Service as ServiceDto;
@@ -100,5 +102,28 @@ trait CreateServiceables
         $data['service_id'] = $service->getId();
 
         return MerchantModel::factory()->create($data);
+    }
+
+    protected function linkMerchantToProvider(Merchantable $merchant, Providable $provider, $data = [])
+    {
+        $linkMerchantToProvider = 'linkMerchantToProvider' . Str::studly(Config::get('serviceable.defaults.driver'));
+
+        $this->$linkMerchantToProvider($merchant, $provider, $data);
+    }
+
+    protected function linkMerchantToProviderConfig(Merchantable $merchant, Providable $provider, $data)
+    {
+        Config::set(
+            $providers = Str::slug($merchant->getService()->getId()) . '.merchants.' . $merchant->getId() . '.providers',
+            array_merge(
+                Config::get($providers, []),
+                [$provider->getId() => $data]
+            )
+        );
+    }
+
+    protected function linkMerchantToProviderDatabase(Merchantable $merchant, Providable $provider, $data)
+    {
+        $merchant->providers()->sync([$provider->getId() => $data], false);
     }
 }

--- a/tests/Traits/SetUpMode.php
+++ b/tests/Traits/SetUpMode.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Payavel\Serviceable\Tests\Traits;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Str;
+
+trait SetUpMode
+{
+    protected function setUpMode($service = null)
+    {
+        Config::set(($service ? Str::slug($service->getId()) : 'serviceable') . '.test_mode', $this->fake ?? false);
+    }
+}

--- a/tests/Unit/ConfigServiceTest.php
+++ b/tests/Unit/ConfigServiceTest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Payavel\Serviceable\Tests\Unit;
+
+class ConfigServiceTest extends TestService
+{
+    public $driver = 'config';
+}

--- a/tests/Unit/DatabaseServiceTest.php
+++ b/tests/Unit/DatabaseServiceTest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Payavel\Serviceable\Tests\Unit;
+
+class DatabaseServiceTest extends TestService
+{
+    public $driver = 'database';
+}

--- a/tests/Unit/FakeConfigServiceTest.php
+++ b/tests/Unit/FakeConfigServiceTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Payavel\Serviceable\Tests\Unit;
+
+class FakeConfigServiceTest extends TestService
+{
+    public $driver = 'config';
+    public $fake = true;
+}

--- a/tests/Unit/FakeDatabaseServiceTest.php
+++ b/tests/Unit/FakeDatabaseServiceTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Payavel\Serviceable\Tests\Unit;
+
+class FakeDatabaseServiceTest extends TestService
+{
+    public $driver = 'database';
+    public $fake = true;
+}

--- a/tests/Unit/TestService.php
+++ b/tests/Unit/TestService.php
@@ -2,7 +2,9 @@
 
 namespace Payavel\Serviceable\Tests\Unit;
 
+use Exception;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Str;
 use Payavel\Serviceable\Service;
 use Payavel\Serviceable\ServiceResponse;
 use Payavel\Serviceable\Tests\Services\Mock\FakeMockRequest;
@@ -18,38 +20,123 @@ class TestService extends TestCase
     use CreateServiceables,
         SetUpMode;
 
+    private $serviceable;
+    private $providable;
+    private $merchantable;
+
     private $service;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $service = $this->createService([
+        $this->serviceable = $this->createService([
             'id' => 'mock',
             'name' => 'Mock',
         ]);
 
-        $provider = $this->createProvider($service, [
+        $this->providable = $this->createProvider($this->serviceable, [
             'id' => 'test',
             'name' => 'Test',
             'request_class' => TestMockRequest::class,
             'response_class' => TestMockResponse::class,
         ]);
 
-        $merchant = $this->createMerchant($service, [
+        $this->merchantable = $this->createMerchant($this->serviceable, [
             'id' => 'x',
             'name' => 'X',
         ]);
 
-        $this->linkMerchantToProvider($merchant, $provider);
+        $this->linkMerchantToProvider($this->merchantable, $this->providable);
 
-        Config::set('mock.mock', [
+        Config::set(Str::slug($this->serviceable->getId()) . '.defaults.provider', $this->providable->getId());
+        Config::set(Str::slug($this->serviceable->getId()) . '.defaults.merchant', $this->merchantable->getId());
+        Config::set(Str::slug($this->serviceable->getId()) . '.mock', [
             'request_class' => FakeMockRequest::class,
             'response_class' => FakeMockResponse::class,
         ]);
 
-        $this->setUpMode($service);
+        $this->setUpMode($this->serviceable);
 
-        $this->service = new Service($service);
+        $this->service = new Service($this->serviceable);
+    }
+
+    /** @test */
+    public function set_provider_and_merchant_fluently()
+    {
+        $response = $this->service
+            ->provider($this->providable)
+            ->merchant($this->merchantable)
+            ->getIdentity();
+
+        $this->assertEquals(
+            Config::get(Str::slug($this->serviceable->getId()) . '.test_mode')
+                ? 'Fake'
+                : 'Real',
+            $response->data
+        );
+
+        $this->assertResponseIsConfigured($response);
+    }
+
+    /** @test */
+    public function setting_invalid_driver_throws_exception()
+    {
+        Config::set(Str::slug($this->serviceable->getId()) . '.defaults.driver', 'invalid');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Invalid driver provided.');
+
+        $service = new Service($this->serviceable);
+    }
+
+    /** @test */
+    public function setting_invalid_provider_throws_exception()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Invalid provider.');
+
+        $this->service->setProvider('invalid');
+    }
+
+    /** @test */
+    public function setting_invalid_merchant_throws_exception()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Invalid merchant.');
+
+        $this->service->setMerchant('invalid');
+    }
+
+    /** @test */
+    public function setting_incompatible_merchant_provider_throws_exception()
+    {
+        $incompatibleMerchant = $this->createMerchant($this->serviceable);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('The ' . $incompatibleMerchant->getName() . ' merchant is not supported by the ' . $this->providable->getName() . ' provider.');
+
+        $this->service->provider($this->providable)->merchant($incompatibleMerchant)->getIdentity();
+    }
+
+    /** @test */
+    public function resetting_service_to_default_configuration()
+    {
+        $alternativeMerchant = $this->createMerchant($this->serviceable);
+        $this->linkMerchantToProvider($alternativeMerchant, $this->providable);
+
+        $this->service->provider($this->providable)->merchant($alternativeMerchant);
+
+        $this->assertEquals($alternativeMerchant->getId(), $this->service->getIdentity()->merchant->getId());
+
+        $this->service->reset();
+
+        $this->assertEquals($this->merchantable->getId(), $this->service->getIdentity()->merchant->getId());
+    }
+
+    protected function assertResponseIsConfigured(ServiceResponse $response)
+    {
+        $this->assertEquals($this->providable->getId(), $response->provider->getId());
+        $this->assertEquals($this->merchantable->getId(), $response->merchant->getId());
     }
 }

--- a/tests/Unit/TestService.php
+++ b/tests/Unit/TestService.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Payavel\Serviceable\Tests\Unit;
+
+use Illuminate\Support\Facades\Config;
+use Payavel\Serviceable\Service;
+use Payavel\Serviceable\ServiceResponse;
+use Payavel\Serviceable\Tests\Services\Mock\FakeMockRequest;
+use Payavel\Serviceable\Tests\Services\Mock\FakeMockResponse;
+use Payavel\Serviceable\Tests\Services\Mock\TestMockRequest;
+use Payavel\Serviceable\Tests\Services\Mock\TestMockResponse;
+use Payavel\Serviceable\Tests\TestCase;
+use Payavel\Serviceable\Tests\Traits\CreateServiceables;
+use Payavel\Serviceable\Tests\Traits\SetUpMode;
+
+class TestService extends TestCase
+{
+    use CreateServiceables,
+        SetUpMode;
+
+    private $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $service = $this->createService([
+            'id' => 'mock',
+            'name' => 'Mock',
+        ]);
+
+        $provider = $this->createProvider($service, [
+            'id' => 'test',
+            'name' => 'Test',
+            'request_class' => TestMockRequest::class,
+            'response_class' => TestMockResponse::class,
+        ]);
+
+        $merchant = $this->createMerchant($service, [
+            'id' => 'x',
+            'name' => 'X',
+        ]);
+
+        $this->linkMerchantToProvider($merchant, $provider);
+
+        Config::set('mock.mock', [
+            'request_class' => FakeMockRequest::class,
+            'response_class' => FakeMockResponse::class,
+        ]);
+
+        $this->setUpMode($service);
+
+        $this->service = new Service($service);
+    }
+}


### PR DESCRIPTION
### **What does this PR do?** :robot:
Adds a whole bunch of unit tests.

### **How should this be tested?** :microscope:
What it test itself 😉.

### **Any background context you would like to provide?** :construction:
These tests were initially created in the `payavel/checkout` repo, when `payavel/serviceable` did not exist.

### **Does this relate to any issue?** :link:
Closes #3 
