### PR TITLE
Prefer arrow functions over anonymous functions where possible.

### DIFF
--- a/database/factories/MerchantFactory.php
+++ b/database/factories/MerchantFactory.php
@@ -41,9 +41,9 @@ class MerchantFactory extends Factory
     {
         return $this->afterMaking(function (Merchant $merchant) {
             if(is_null($merchant->service_id)) {
-                $service = Service::inRandomOrder()->firstOr(function () {
-                    return Service::factory()->create();
-                });
+                $service = Service::inRandomOrder()->firstOr(
+                    fn () => Service::factory()->create()
+                );
 
                 $merchant->service_id = $service->id;
             }

--- a/database/factories/ProviderFactory.php
+++ b/database/factories/ProviderFactory.php
@@ -40,9 +40,9 @@ class ProviderFactory extends Factory
     {
         return $this->afterMaking(function (Provider $provider) {
             if(is_null($provider->service_id)) {
-                $service = Service::inRandomOrder()->firstOr(function () {
-                    return Service::factory()->create();
-                });
+                $service = Service::inRandomOrder()->firstOr(
+                    fn () => Service::factory()->create()
+                );
 
                 $provider->service_id = $service->id;
             }

--- a/src/Console/Commands/Install.php
+++ b/src/Console/Commands/Install.php
@@ -147,16 +147,16 @@ class Install extends Command
     {
         $this->call("service:provider", ['--service' => $this->service->getId(), '--fake' => true]);
 
-        $this->providers->each(function ($provider) {
-            $this->call(
+        $this->providers->each(
+            fn ($provider) =>  $this->call(
                 "service:provider",
                 [
                     'provider' => $provider['name'],
                     '--service' => $this->service->getId(),
                     '--id' => $provider['id']
                 ]
-            );
-        });
+            )
+        );
     }
 
     protected function setService()
@@ -185,9 +185,15 @@ class Install extends Command
             ]);
         } while ($this->confirm('Would you like to add another '. Str::lower($this->service->getName()) .' provider?', false));
 
-        $this->config['providers'] = $this->providers->reduce(function ($config, $provider) {
-            return $config . $this->makeFile(__DIR__ . '/../../../stubs/config-provider.stub', $provider);
-        }, "");
+        $this->config['providers'] = $this->providers->reduce(
+            fn ($config, $provider) =>
+                $config .
+                $this->makeFile(
+                    __DIR__ . '/../../../stubs/config-provider.stub',
+                    $provider
+                ),
+            ""
+        );
 
         $this->config['defaults']['provider'] = $this->providers->count() > 1
             ? $this->choice('Which provider will be used as default?', $this->providers->pluck('id')->all())
@@ -219,16 +225,28 @@ class Install extends Command
                 )
                 : [$this->providers->first()['id']];
 
-            $merchant['providers'] = collect($providers)->reduce(function ($config, $provider, $index) use ($providers) {
-                return $config . $this->makeFile(__DIR__ . '/../../../stubs/config-merchant-providers.stub', ['id' => $provider]) . ($index < count($providers) - 1 ? "\n" : "");
-            }, "");
+            $merchant['providers'] = collect($providers)->reduce(
+                fn ($config, $provider, $index) =>
+                    $config .
+                    $this->makeFile(
+                        __DIR__ . '/../../../stubs/config-merchant-providers.stub',
+                        ['id' => $provider]
+                    ) .
+                    ($index < count($providers) - 1 ? "\n" : ""),
+                ""
+            );
 
             $this->merchants->push($merchant);
         } while ($this->confirm('Would you like to add another ' . Str::lower($this->service->getName()) . ' merchant?', false));
 
-        $this->config['merchants'] = $this->merchants->reduce(function ($config, $merchant) {
-            return $config . $this->makeFile(__DIR__ . '/../../../stubs/config-merchant.stub', $merchant);
-        }, "");
+        $this->config['merchants'] = $this->merchants->reduce(
+            fn ($config, $merchant) =>
+                $config . $this->makeFile(
+                    __DIR__ . '/../../../stubs/config-merchant.stub',
+                    $merchant
+            ),
+            ""
+        );
 
         $this->config['defaults']['merchant'] = $this->merchants->count() > 1
             ? $this->choice('Which merchant will be used as default?', $this->merchants->pluck('id')->all())

--- a/src/DataTransferObjects/Merchant.php
+++ b/src/DataTransferObjects/Merchant.php
@@ -61,17 +61,18 @@ class Merchant implements Merchantable
     {
         if (! isset($this->providers)) {
             $this->attributes['providers'] = (new Collection($this->config($this->service->getId(), 'merchants.' . $this->attributes['id'] . '.providers', [])))
-                ->map(function ($provider, $key) {
-                    if (is_array($provider)) {
-                        return array_merge(
+                ->map(fn ($provider, $key) =>
+                    is_array($provider)
+                        ? array_merge(
                             ['id' => $key],
                             $this->config($this->service->getId(), 'providers.' . $key),
                             $provider
-                        );
-                    }
-
-                    return array_merge(['id' => $provider], $this->config($this->service->getId(), 'providers.' . $provider));
-                });
+                        )
+                        : array_merge(
+                            ['id' => $provider],
+                            $this->config($this->service->getId(), 'providers.' . $provider)
+                        )
+                );
         }
 
         return $this->attributes['providers'];

--- a/src/Drivers/ConfigDriver.php
+++ b/src/Drivers/ConfigDriver.php
@@ -130,8 +130,8 @@ class ConfigDriver extends ServiceDriver
      */
     public static function services()
     {
-        return collect(Config::get('serviceable.services', []))->map(function ($value, $key) {
-            return new Service(array_merge(['id' => $key], $value));
-        })->values();
+        return collect(Config::get('serviceable.services', []))->map(
+            fn ($value, $key) => new Service(array_merge(['id' => $key], $value))
+        )->values();
     }
 }


### PR DESCRIPTION
### **What does this PR do?** :robot:
Updates all single statement anonymous functions to arrow function to improve code readability.

### **Any background context you would like to provide?** :construction:
Initially, I though php arrow functions would support multiple statements like `.js` does, but that is not the case.

### **Does this relate to any issue?** :link:
Closes #5 
