### PR TITLE
Rename 'mock' config key to 'testing'.

### DIFF
--- a/config/serviceable.php
+++ b/config/serviceable.php
@@ -33,6 +33,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Serviceable Test Mode
+    |--------------------------------------------------------------------------
+    |
+    | When set to true, the provider & merchant will be shared with the respective
+    | fake service request, this allows you to mock your responses as you wish.
+    | Note that if the service defines the test_mode, it will be prioritized.
+    |
+    */
+    'test_mode' => env('SERVICE_TEST_MODE', false),
+
+    /*
+    |--------------------------------------------------------------------------
     | Service Stubs
     |--------------------------------------------------------------------------
     |

--- a/src/Service.php
+++ b/src/Service.php
@@ -210,7 +210,7 @@ class Service
         }
 
         $gateway = $this->config($this->service->getId(), 'test_mode')
-            ? $this->config($this->service->getId(), 'mock.request_class')
+            ? $this->config($this->service->getId(), 'testing.request_class')
             : $this->driver->resolveGatewayClass($provider);
 
         if (! class_exists($gateway)) {

--- a/stubs/config-service.stub
+++ b/stubs/config-service.stub
@@ -31,7 +31,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | {{ Title }} Mocking
+    | {{ Title }} Testing
     |--------------------------------------------------------------------------
     |
     | This option allows you to define the location of the fake {{ service }}
@@ -39,7 +39,7 @@ return [
     | is set to true. Also, feel free to add any other settings here.
     |
     */
-    'mock' => [
+    'testing' => [
         'request_class' => \App\Services\{{ Service }}\Fake{{ Service }}Request::class,
         'response_class' => \App\Services\{{ Service }}\Fake{{ Service }}Response::class,
     ],

--- a/tests/Unit/TestService.php
+++ b/tests/Unit/TestService.php
@@ -51,7 +51,7 @@ class TestService extends TestCase
 
         Config::set(Str::slug($this->serviceable->getId()) . '.defaults.provider', $this->providable->getId());
         Config::set(Str::slug($this->serviceable->getId()) . '.defaults.merchant', $this->merchantable->getId());
-        Config::set(Str::slug($this->serviceable->getId()) . '.mock', [
+        Config::set(Str::slug($this->serviceable->getId()) . '.testing', [
             'request_class' => FakeMockRequest::class,
             'response_class' => FakeMockResponse::class,
         ]);


### PR DESCRIPTION
### **What does this PR do?** :robot:
- Renames 'mock' config key to 'testing'.
- Adds default config for 'serviceable.test_mode` as a fallback for all services.

### **Does this relate to any issue?** :link:
Closes #6 
