### PR TITLE
[3.x] Update typing.

### DIFF
--- a/database/factories/AccountFactory.php
+++ b/database/factories/AccountFactory.php
@@ -21,7 +21,7 @@ class AccountFactory extends Factory
      *
      * @return array
      */
-    public function definition()
+    public function definition(): array
     {
         $account = Str::remove(['\'', ','], $this->faker->unique()->company());
 
@@ -34,12 +34,12 @@ class AccountFactory extends Factory
     /**
      * Configure the model factory.
      *
-     * @return $this
+     * @return static
      */
-    public function configure()
+    public function configure(): static
     {
         return $this->afterMaking(function (Account $account) {
-            if(is_null($account->service_id)) {
+            if (is_null($account->service_id)) {
                 $account->service_id = is_null($service = Service::all()->random())
                     ? Str::lower($this->faker->unique()->word())
                     : $service->getId();

--- a/database/factories/AccountFactory.php
+++ b/database/factories/AccountFactory.php
@@ -34,7 +34,7 @@ class AccountFactory extends Factory
     /**
      * Configure the model factory.
      *
-     * @return static
+     * @return \Payavel\Orchestration\Database\Factories\AccountFactory
      */
     public function configure(): static
     {

--- a/database/factories/ProviderFactory.php
+++ b/database/factories/ProviderFactory.php
@@ -21,7 +21,7 @@ class ProviderFactory extends Factory
      *
      * @return array
      */
-    public function definition()
+    public function definition(): array
     {
         $provider = Str::remove(['\'', ','], $this->faker->unique()->company());
 
@@ -34,12 +34,12 @@ class ProviderFactory extends Factory
     /**
      * Configure the model factory.
      *
-     * @return $this
+     * @return static
      */
-    public function configure()
+    public function configure(): static
     {
         return $this->afterMaking(function (Provider $provider) {
-            if(is_null($provider->service_id)) {
+            if (is_null($provider->service_id)) {
                 $provider->service_id = is_null($service = Service::all()->random())
                     ? Str::lower($this->faker->unique()->word())
                     : $service->getId();

--- a/database/factories/ProviderFactory.php
+++ b/database/factories/ProviderFactory.php
@@ -34,7 +34,7 @@ class ProviderFactory extends Factory
     /**
      * Configure the model factory.
      *
-     * @return static
+     * @return \Payavel\Orchestration\Database\Factories\ProviderFactory
      */
     public function configure(): static
     {

--- a/database/migrations/2024_01_01_000001_create_base_orchestration_tables.php
+++ b/database/migrations/2024_01_01_000001_create_base_orchestration_tables.php
@@ -10,7 +10,7 @@ return new class () extends Migration {
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('providers', function (Blueprint $table) {
             $table->string('id')->primary();
@@ -47,7 +47,7 @@ return new class () extends Migration {
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('account_provider');
         Schema::dropIfExists('accounts');

--- a/src/Console/Commands/OrchestrateProvider.php
+++ b/src/Console/Commands/OrchestrateProvider.php
@@ -23,18 +23,18 @@ class OrchestrateProvider extends Command
      *
      * @var string
      */
-    protected string $signature = 'orchestrate:provider
-                                    {provider? : The provider name}
-                                    {--id= : The provider ID}
-                                    {--service= : The service ID}
-                                    {--fake : Generates a gateway to be used for testing purposes}';
+    protected $signature = 'orchestrate:provider
+                            {provider? : The provider name}
+                            {--id= : The provider ID}
+                            {--service= : The service ID}
+                            {--fake : Generates a gateway to be used for testing purposes}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected string $description = 'Scaffold a new service provider\'s gateway request and response classes.';
+    protected $description = 'Scaffold a new service provider\'s gateway request and response classes.';
 
     /**
      * The provider's service config.

--- a/src/Console/Commands/OrchestrateProvider.php
+++ b/src/Console/Commands/OrchestrateProvider.php
@@ -48,14 +48,14 @@ class OrchestrateProvider extends Command
      *
      * @var string
      */
-    protected string $name;
+    protected string $providerName;
 
     /**
      * The service provider's id.
      *
      * @var string
      */
-    protected string $id;
+    protected string $providerId;
 
     /**
      * Executes the console command.
@@ -83,15 +83,15 @@ class OrchestrateProvider extends Command
         }
 
         if ($this->option('fake', false)) {
-            $this->name = 'Fake';
-            $this->id = 'fake';
+            $this->providerName = 'Fake';
+            $this->providerId = 'fake';
 
             return true;
         }
 
-        $this->name = trim($this->argument('provider') ?? $this->askName('provider'));
+        $this->providerName = trim($this->argument('provider') ?? $this->askName('provider'));
 
-        $this->id = $this->option('id') ?? $this->askId('provider', $this->name);
+        $this->providerId = $this->option('id') ?? $this->askId('provider', $this->providerName);
 
         return true;
     }
@@ -104,7 +104,7 @@ class OrchestrateProvider extends Command
     protected function generateProvider(): void
     {
         $service = Str::studly($this->serviceConfig->id);
-        $provider = Str::studly($this->id);
+        $provider = Str::studly($this->providerId);
 
         static::putFile(
             app_path($requestPath = join_paths('Services', $service, "{$provider}{$service}Request.php")),

--- a/src/Console/Commands/OrchestrateProvider.php
+++ b/src/Console/Commands/OrchestrateProvider.php
@@ -23,48 +23,48 @@ class OrchestrateProvider extends Command
      *
      * @var string
      */
-    protected $signature = 'orchestrate:provider
-                            {provider? : The provider name}
-                            {--id= : The provider ID}
-                            {--service= : The service ID}
-                            {--fake : Generates a gateway to be used for testing purposes}';
+    protected string $signature = 'orchestrate:provider
+                                    {provider? : The provider name}
+                                    {--id= : The provider ID}
+                                    {--service= : The service ID}
+                                    {--fake : Generates a gateway to be used for testing purposes}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Scaffold a new service provider\'s gateway request and response classes.';
+    protected string $description = 'Scaffold a new service provider\'s gateway request and response classes.';
 
     /**
      * The provider's service config.
      *
      * @var \Payavel\Orchestration\ServiceConfig
      */
-    protected $serviceConfig;
+    protected ServiceConfig $serviceConfig;
 
     /**
      * The service provider's name.
      *
      * @var string
      */
-    protected $name;
+    protected string $name;
 
     /**
      * The service provider's id.
      *
      * @var string
      */
-    protected $id;
+    protected string $id;
 
     /**
-     * Execute the console command.
+     * Executes the console command.
      *
      * @return void
      */
-    public function handle()
+    public function handle(): void
     {
-        if(! $this->setProperties()) {
+        if (! $this->setProperties()) {
             return;
         }
 
@@ -72,11 +72,11 @@ class OrchestrateProvider extends Command
     }
 
     /**
-     * Format the service provider's properties.
+     * Formats the service provider's properties.
      *
      * @return bool
      */
-    protected function setProperties()
+    protected function setProperties(): bool
     {
         if (! $this->setService()) {
             return false;
@@ -97,11 +97,11 @@ class OrchestrateProvider extends Command
     }
 
     /**
-     * Generated the provider gateway files.
+     * Generates the provider gateway files.
      *
      * @return void
      */
-    protected function generateProvider()
+    protected function generateProvider(): void
     {
         $service = Str::studly($this->serviceConfig->id);
         $provider = Str::studly($this->id);
@@ -134,11 +134,11 @@ class OrchestrateProvider extends Command
     }
 
     /**
-     * Set the service property.
+     * Sets the service property.
      *
      * @return bool
      */
-    protected function setService()
+    protected function setService(): bool
     {
         if (! is_null($this->option('service')) && is_null($serviceConfig = ServiceConfig::find($this->option('service')))) {
             error("Service with id {$this->option('service')} does not exist.");

--- a/src/Console/Commands/OrchestrateService.php
+++ b/src/Console/Commands/OrchestrateService.php
@@ -3,9 +3,11 @@
 namespace Payavel\Orchestration\Console\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
 use Payavel\Orchestration\ServiceConfig;
+use Payavel\Orchestration\ServiceDriver;
 use Payavel\Orchestration\Traits\AsksQuestions;
 use Payavel\Orchestration\Traits\GeneratesFiles;
 
@@ -25,58 +27,58 @@ class OrchestrateService extends Command
      *
      * @var string
      */
-    protected $signature = 'orchestrate:service
-                            {service? : The service name}
-                            {--id= : The service ID }';
+    protected string $signature = 'orchestrate:service
+                                    {service? : The service name}
+                                    {--id= : The service ID }';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Install a new service into the application.';
+    protected string $description = 'Install a new service into the application.';
 
     /**
      * The service config.
      *
      * @var \Payavel\Orchestration\ServiceConfig
      */
-    protected $serviceConfig;
+    protected ServiceConfig $serviceConfig;
 
     /**
      * The driver to execute the new service.
      *
      * @var Payavel\Orchestration\ServiceDriver
      */
-    protected $driver;
+    protected ServiceDriver $driver;
 
     /**
      * The collected providers.
      *
      * @var \Illuminate\Support\Collection
      */
-    protected $providers;
+    protected Collection $providers;
 
     /**
      * The collected accounts.
      *
      * @var \Illuminate\Support\Collection
      */
-    protected $accounts;
+    protected Collection $accounts;
 
     /**
      * The defaults to be set.
      *
      * @var array
      */
-    protected $defaults = [];
+    protected array $defaults = [];
 
     /**
-     * Execute the console command.
+     * Executes the console command.
      *
      * @return void
      */
-    public function handle()
+    public function handle(): void
     {
         $this->setProperties();
 
@@ -88,11 +90,11 @@ class OrchestrateService extends Command
     }
 
     /**
-     * Sets the properties necessary to handle this command.
+     * Sets the necessary properties to handle this command.
      *
      * @return void
      */
-    protected function setProperties()
+    protected function setProperties(): void
     {
         $this->setServiceConfig();
         $this->setDriver();
@@ -105,7 +107,7 @@ class OrchestrateService extends Command
      *
      * @return void
      */
-    protected function generateService()
+    protected function generateService(): void
     {
         $this->driver::generateService($this->serviceConfig, $this->providers, $this->accounts, $this->defaults);
 
@@ -141,7 +143,7 @@ class OrchestrateService extends Command
      *
      * @return void
      */
-    protected function generateProviders()
+    protected function generateProviders(): void
     {
         $this->call("orchestrate:provider", ['--service' => $this->serviceConfig->id, '--fake' => true]);
 
@@ -157,11 +159,11 @@ class OrchestrateService extends Command
     }
 
     /**
-     * Request service information and set the config.
+     * Requests the service information and sets the config.
      *
      * @return void
      */
-    protected function setServiceConfig()
+    protected function setServiceConfig(): void
     {
         $name = trim($this->argument('service') ?? $this->askName('service'));
         $id = $this->option('id') ?? $this->askId('service', $name);
@@ -172,11 +174,11 @@ class OrchestrateService extends Command
     }
 
     /**
-     * Query for driver information and set the corresponding class.
+     * Queries for driver information and sets the corresponding class.
      *
      * @return void
      */
-    protected function setDriver()
+    protected function setDriver(): void
     {
         $this->defaults['driver'] = select(
             label: "Choose a driver for the {$this->serviceConfig->name} service.",
@@ -188,11 +190,11 @@ class OrchestrateService extends Command
     }
 
     /**
-     * Query for provider information, generate the service & set the config for chosen providers.
+     * Queries the provider information, generates the service and sets the config for the chosen providers.
      *
      * @return void
      */
-    protected function setProviders()
+    protected function setProviders(): void
     {
         $this->providers = collect([]);
 
@@ -217,11 +219,11 @@ class OrchestrateService extends Command
     }
 
     /**
-     * Query account information & set the config for chosen accounts.
+     * Queries the account information and sets the config for the chosen accounts.
      *
      * @return void
      */
-    protected function setAccounts()
+    protected function setAccounts(): void
     {
         $this->accounts = collect([]);
 
@@ -247,11 +249,11 @@ class OrchestrateService extends Command
     }
 
     /**
-     * If orchestration config file does not exist yet, generate it.
+     * Generates the orchestration config file if it does not exist.
      *
      * @return void
      */
-    protected function makeSureOrchestraIsReady()
+    protected function makeSureOrchestraIsReady(): void
     {
         if (file_exists(config_path('orchestration.php'))) {
             return;

--- a/src/Console/Commands/OrchestrateService.php
+++ b/src/Console/Commands/OrchestrateService.php
@@ -43,7 +43,7 @@ class OrchestrateService extends Command
      *
      * @var \Payavel\Orchestration\ServiceConfig
      */
-    protected ServiceConfig $serviceConfig;
+    protected ?ServiceConfig $serviceConfig = null;
 
     /**
      * The driver to execute the new service.

--- a/src/Console/Commands/OrchestrateService.php
+++ b/src/Console/Commands/OrchestrateService.php
@@ -27,16 +27,16 @@ class OrchestrateService extends Command
      *
      * @var string
      */
-    protected string $signature = 'orchestrate:service
-                                    {service? : The service name}
-                                    {--id= : The service ID }';
+    protected $signature = 'orchestrate:service
+                            {service? : The service name}
+                            {--id= : The service ID }';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected string $description = 'Install a new service into the application.';
+    protected $description = 'Install a new service into the application.';
 
     /**
      * The service config.

--- a/src/Console/Commands/OrchestrateService.php
+++ b/src/Console/Commands/OrchestrateService.php
@@ -48,9 +48,9 @@ class OrchestrateService extends Command
     /**
      * The driver to execute the new service.
      *
-     * @var Payavel\Orchestration\ServiceDriver
+     * @var string
      */
-    protected ServiceDriver $driver;
+    protected string $driver;
 
     /**
      * The collected providers.

--- a/src/Console/Commands/OrchestrateStubs.php
+++ b/src/Console/Commands/OrchestrateStubs.php
@@ -19,16 +19,16 @@ class OrchestrateStubs extends Command
      *
      * @var string
      */
-    protected string $signature = 'orchestrate:stubs
-                                    {stub? : The stub file}
-                                    {--service= : The service}';
+    protected $signature = 'orchestrate:stubs
+                            {stub? : The stub file}
+                            {--service= : The service}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected string $description = 'Publishes this package\'s stub files.';
+    protected $description = 'Publishes this package\'s stub files.';
 
     /**
      * Stubs that can be overridden on the orchestration level.

--- a/src/Console/Commands/OrchestrateStubs.php
+++ b/src/Console/Commands/OrchestrateStubs.php
@@ -19,23 +19,23 @@ class OrchestrateStubs extends Command
      *
      * @var string
      */
-    protected $signature = 'orchestrate:stubs
-                            {stub? : The stub file}
-                            {--service= : The service}';
+    protected string $signature = 'orchestrate:stubs
+                                    {stub? : The stub file}
+                                    {--service= : The service}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Publishes this package\'s stub files.';
+    protected string $description = 'Publishes this package\'s stub files.';
 
     /**
      * Stubs that can be overridden on the orchestration level.
      *
-     * @var string[]
+     * @var array<string>
      */
-    public static $baseStubs = [
+    public static array $baseStubs = [
       'config-service',
       'config-service-database',
       'config-service-account',
@@ -53,19 +53,19 @@ class OrchestrateStubs extends Command
     /**
      * Stubs that can be overridden on a service level.
      *
-     * @var string[]
+     * @var array<string>
      */
-    public static $serviceSpecificStubs = [
+    public static array $serviceSpecificStubs = [
         'service-request',
         'service-response',
     ];
 
     /**
-     * Execute the console command.
+     * Executes the console command.
      *
      * @return void
      */
-    public function handle()
+    public function handle(): void
     {
         $stubs = is_null($this->option('service'))
             ? static::$baseStubs
@@ -87,7 +87,7 @@ class OrchestrateStubs extends Command
                 : ('/'.$this->option('service'))
         );
 
-        foreach($stubs as $stub) {
+        foreach ($stubs as $stub) {
             static::putFile(
                 base_path(join_paths($directory, "{$stub}.stub")),
                 file_get_contents(__DIR__."/../../../stubs/{$stub}.stub")

--- a/src/Contracts/Accountable.php
+++ b/src/Contracts/Accountable.php
@@ -5,16 +5,16 @@ namespace Payavel\Orchestration\Contracts;
 interface Accountable
 {
     /**
-     * Get the accountable id.
+     * Gets the accountable id.
      *
      * @return string|int
      */
-    public function getId();
+    public function getId(): string|int;
 
     /**
-     * Get the accountable name.
+     * Gets the accountable name.
      *
      * @return string
      */
-    public function getName();
+    public function getName(): string;
 }

--- a/src/Contracts/Orchestrable.php
+++ b/src/Contracts/Orchestrable.php
@@ -2,6 +2,8 @@
 
 namespace Payavel\Orchestration\Contracts;
 
+use Payavel\Orchestration\Service;
+
 interface Orchestrable
 {
     /**
@@ -9,19 +11,19 @@ interface Orchestrable
      *
      * @return \Payavel\Orchestration\Service
      */
-    public function getService();
+    public function getService(): Service;
 
     /**
      * Gets the orchestrable service's provider.
      *
      * @return \Payavel\Orchestration\Contracts\Providable
      */
-    public function getProvider();
+    public function getProvider(): Providable;
 
     /**
      * Gets the orchestrable service's account.
      *
      * @return \Payavel\Orchestration\Contracts\Accountable
      */
-    public function getAccount();
+    public function getAccount(): Accountable;
 }

--- a/src/Contracts/Providable.php
+++ b/src/Contracts/Providable.php
@@ -5,16 +5,16 @@ namespace Payavel\Orchestration\Contracts;
 interface Providable
 {
     /**
-     * Get the providable id.
+     * Gets the providable id.
      *
      * @return string|int
      */
-    public function getId();
+    public function getId(): string|int;
 
     /**
-     * Get the providable name.
+     * Gets the providable name.
      *
      * @return string
      */
-    public function getName();
+    public function getName(): string;
 }

--- a/src/Drivers/ConfigDriver.php
+++ b/src/Drivers/ConfigDriver.php
@@ -75,7 +75,7 @@ class ConfigDriver extends ServiceDriver
      * @param \Payavel\Orchestration\Contracts\Accountable|null $account
      * @return string|int
      */
-    public function getDefaultProvider(Accountable $account = null)
+    public function getDefaultProvider(?Accountable $account = null)
     {
         if (
             ! $account instanceof Account ||
@@ -115,7 +115,7 @@ class ConfigDriver extends ServiceDriver
      * @param \Payavel\Orchestration\Contracts\Providable|null $provider
      * @return string|int
      */
-    public function getDefaultAccount(Providable $provider = null)
+    public function getDefaultAccount(?Providable $provider = null)
     {
         return $this->serviceConfig->get('defaults.account');
     }

--- a/src/Drivers/ConfigDriver.php
+++ b/src/Drivers/ConfigDriver.php
@@ -12,6 +12,7 @@ use Payavel\Orchestration\Fluent\Account;
 use Payavel\Orchestration\Fluent\Provider;
 use Payavel\Orchestration\ServiceConfig;
 use Payavel\Orchestration\ServiceDriver;
+use Payavel\Orchestration\ServiceRequest;
 use Payavel\Orchestration\Traits\GeneratesFiles;
 
 use function Laravel\Prompts\info;
@@ -26,18 +27,18 @@ class ConfigDriver extends ServiceDriver
      *
      * @var \Illuminate\Support\Collection
      */
-    protected $providers;
+    protected Collection $providers;
 
     /**
      * Collection of the service's accounts.
      *
      * @var \Illuminate\Support\Collection
      */
-    protected $accounts;
+    protected Collection $accounts;
 
 
     /**
-     * Collect the service's providers & accounts.
+     * Collects the service's providers & accounts.
      */
     public function __construct(ServiceConfig $serviceConfig)
     {
@@ -48,12 +49,12 @@ class ConfigDriver extends ServiceDriver
     }
 
     /**
-     * Resolve the providable instance.
+     * Resolves the providable instance.
      *
      * @param \Payavel\Orchestration\Contracts\Providable|string $provider
      * @return \Payavel\Orchestration\Contracts\Providable|null
      */
-    public function resolveProvider($provider)
+    public function resolveProvider(Providable|string|int $provider): ?Providable
     {
         if ($provider instanceof Provider) {
             return $provider;
@@ -70,12 +71,12 @@ class ConfigDriver extends ServiceDriver
     }
 
     /**
-     * Get the default providable identifier.
+     * Gets the default providable identifier.
      *
      * @param \Payavel\Orchestration\Contracts\Accountable|null $account
      * @return string|int
      */
-    public function getDefaultProvider(?Accountable $account = null)
+    public function getDefaultProvider(?Accountable $account = null): string|int
     {
         if (
             ! $account instanceof Account ||
@@ -88,12 +89,12 @@ class ConfigDriver extends ServiceDriver
     }
 
     /**
-     * Resolve the accountable instance.
+     * Resolves the accountable instance.
      *
      * @param \Payavel\Orchestration\Contracts\Accountable|string|int $account
      * @return \Payavel\Orchestration\Contracts\Accountable|null
      */
-    public function resolveAccount($account)
+    public function resolveAccount(Accountable|string|int $account): ?Accountable
     {
         if ($account instanceof Account) {
             return $account;
@@ -110,26 +111,26 @@ class ConfigDriver extends ServiceDriver
     }
 
     /**
-     * Get the default accountable identifier.
+     * Gets the default accountable identifier.
      *
      * @param \Payavel\Orchestration\Contracts\Providable|null $provider
      * @return string|int
      */
-    public function getDefaultAccount(?Providable $provider = null)
+    public function getDefaultAccount(?Providable $provider = null): string|int
     {
         return $this->serviceConfig->get('defaults.account');
     }
 
     /**
-     * Verify that the account is compatible with the provider.
+     * Verifies that the account is compatible with the provider.
      *
-     * @param \Payavel\Orchestration\Contracts\Providable
-     * @param \Payavel\Orchestration\Contracts\Accountable
+     * @param \Payavel\Orchestration\Fluent\Provider $provider
+     * @param \Payavel\Orchestration\Fluent\Account $account
      * @return void
      *
      * @throws Exception
      */
-    protected function check(Provider $provider, Account $account)
+    protected function check(Provider $provider, Account $account): void
     {
         if (Collection::make($account->get('providers'))->has($provider->id)) {
             return;
@@ -139,7 +140,7 @@ class ConfigDriver extends ServiceDriver
     }
 
     /**
-     * Resolve the gateway.
+     * Resolves the gateway.
      *
      * @param \Payavel\Orchestration\Contracts\Providable $provider
      * @param \Payavel\Orchestration\Contracts\Accountable $account
@@ -147,7 +148,7 @@ class ConfigDriver extends ServiceDriver
      *
      * @throws Exception
      */
-    public function resolveGateway(Providable $provider, Accountable $account)
+    public function resolveGateway(Providable $provider, Accountable $account): ServiceRequest
     {
         $this->check($provider, $account);
 
@@ -167,7 +168,7 @@ class ConfigDriver extends ServiceDriver
     }
 
     /**
-     * Generate the service skeleton based on the current driver.
+     * Generates the service skeleton based on the current driver.
      *
      * @param \Payavel\Orchestration\ServiceConfig $serviceConfig
      * @param \Illuminate\Support\Collection $providers
@@ -175,7 +176,7 @@ class ConfigDriver extends ServiceDriver
      * @param array $defaults
      * @return void
      */
-    public static function generateService(ServiceConfig $serviceConfig, Collection $providers, Collection $accounts, array $defaults)
+    public static function generateService(ServiceConfig $serviceConfig, Collection $providers, Collection $accounts, array $defaults): void
     {
         $data = [];
 

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -14,6 +14,7 @@ use Payavel\Orchestration\Models\Account;
 use Payavel\Orchestration\Models\Provider;
 use Payavel\Orchestration\ServiceConfig;
 use Payavel\Orchestration\ServiceDriver;
+use Payavel\Orchestration\ServiceRequest;
 use Payavel\Orchestration\Traits\GeneratesFiles;
 
 use function Laravel\Prompts\info;
@@ -24,12 +25,12 @@ class DatabaseDriver extends ServiceDriver
     use GeneratesFiles;
 
     /**
-     * Resolve the providable instance.
+     * Resolves the providable instance.
      *
-     * @param \Payavel\Orchestration\Contracts\Providable|string $provider
+     * @param \Payavel\Orchestration\Contracts\Providable|string|int $provider
      * @return \Payavel\Orchestration\Contracts\Providable|null
      */
-    public function resolveProvider($provider)
+    public function resolveProvider(Providable|string|int $provider): ?Providable
     {
         if (! $provider instanceof Provider) {
             $serviceProvider = $this->serviceConfig->get('models.'.Provider::class, Provider::class);
@@ -45,12 +46,12 @@ class DatabaseDriver extends ServiceDriver
     }
 
     /**
-     * Get the default providable identifier.
+     * Gets the default providable identifier.
      *
      * @param \Payavel\Orchestration\Contracts\Accountable|null $account
      * @return string|int
      */
-    public function getDefaultProvider(?Accountable $account = null)
+    public function getDefaultProvider(?Accountable $account = null): string|int
     {
         if (! $account instanceof Account || is_null($provider = $account->default_provider_id)) {
             $provider = $this->serviceConfig->get('defaults.provider');
@@ -60,12 +61,12 @@ class DatabaseDriver extends ServiceDriver
     }
 
     /**
-     * Resolve the accountable instance.
+     * Resolves the accountable instance.
      *
      * @param \Payavel\Orchestration\Contracts\Accountable|string|int $account
      * @return \Payavel\Orchestration\Contracts\Accountable|null
      */
-    public function resolveAccount($account)
+    public function resolveAccount(Accountable|string|int $account): ?Accountable
     {
         if (! $account instanceof Account) {
             $accountModel = $this->serviceConfig->get('models.'.Account::class, Account::class);
@@ -81,26 +82,26 @@ class DatabaseDriver extends ServiceDriver
     }
 
     /**
-     * Get the default accountable identifier.
+     * Gets the default accountable identifier.
      *
      * @param \Payavel\Orchestration\Contracts\Providable|null $provider
      * @return string|int
      */
-    public function getDefaultAccount(?Providable $provider = null)
+    public function getDefaultAccount(?Providable $provider = null): string|int
     {
         return $this->serviceConfig->get('defaults.account');
     }
 
     /**
-     * Verify that the account is compatible with the provider.
+     * Verifies that the account is compatible with the provider.
      *
-     * @param \Payavel\Orchestration\Contracts\Providable
-     * @param \Payavel\Orchestration\Contracts\Accountable
+     * @param \Payavel\Orchestration\Models\Provider $provider
+     * @param \Payavel\Orchestration\Models\Account $account
      * @return void
      *
      * @throws Exception
      */
-    protected function check(Providable $provider, Accountable $account)
+    protected function check(Provider $provider, Account $account): void
     {
         if ($account->providers->contains($provider)) {
             return;
@@ -110,7 +111,7 @@ class DatabaseDriver extends ServiceDriver
     }
 
     /**
-     * Resolve the gateway.
+     * Resolves the gateway.
      *
      * @param \Payavel\Orchestration\Contracts\Providable $provider
      * @param \Payavel\Orchestration\Contracts\Accountable $account
@@ -118,7 +119,7 @@ class DatabaseDriver extends ServiceDriver
      *
      * @throws Exception
      */
-    public function resolveGateway(Providable $provider, Accountable $account)
+    public function resolveGateway(Providable $provider, Accountable $account): ServiceRequest
     {
         $this->check($provider, $account);
 
@@ -138,7 +139,7 @@ class DatabaseDriver extends ServiceDriver
     }
 
     /**
-     * Generate the service skeleton based on the current driver.
+     * Generates the service skeleton based on the current driver.
      *
      * @param \Payavel\Orchestration\ServiceConfig $serviceConfig
      * @param \Illuminate\Support\Collection $providers
@@ -146,7 +147,7 @@ class DatabaseDriver extends ServiceDriver
      * @param array $defaults
      * @return void
      */
-    public static function generateService(ServiceConfig $serviceConfig, Collection $providers, Collection $accounts, array $defaults)
+    public static function generateService(ServiceConfig $serviceConfig, Collection $providers, Collection $accounts, array $defaults): void
     {
         Artisan::call('vendor:publish', ['--tag' => 'payavel-orchestration-migrations']);
 

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -50,7 +50,7 @@ class DatabaseDriver extends ServiceDriver
      * @param \Payavel\Orchestration\Contracts\Accountable|null $account
      * @return string|int
      */
-    public function getDefaultProvider(Accountable $account = null)
+    public function getDefaultProvider(?Accountable $account = null)
     {
         if (! $account instanceof Account || is_null($provider = $account->default_provider_id)) {
             $provider = $this->serviceConfig->get('defaults.provider');
@@ -86,7 +86,7 @@ class DatabaseDriver extends ServiceDriver
      * @param \Payavel\Orchestration\Contracts\Providable|null $provider
      * @return string|int
      */
-    public function getDefaultAccount(Providable $provider = null)
+    public function getDefaultAccount(?Providable $provider = null)
     {
         return $this->serviceConfig->get('defaults.account');
     }

--- a/src/Fluent/Account.php
+++ b/src/Fluent/Account.php
@@ -12,10 +12,11 @@ class Account extends Fluent implements Accountable
      * The service config.
      *
      * @var \Payavel\Orchestration\ServiceConfig
+     * @var string|int
      */
     protected ServiceConfig $serviceConfig;
 
-    public function __construct(ServiceConfig $serviceConfig, $id)
+    public function __construct(ServiceConfig $serviceConfig, string|int $id)
     {
         $this->serviceConfig = $serviceConfig;
 
@@ -26,11 +27,11 @@ class Account extends Fluent implements Accountable
     }
 
     /**
-     * Get an attribute from the fluent instance using "dot" notation.
+     * Gets an attribute from the fluent instance using "dot" notation.
      *
-     * @param  string  $key
-     * @param  string|int|mixed|null $default
-     * @return string|int|mixed|null
+     * @param string $key
+     * @param mixed $default
+     * @return mixed
      */
     public function get($key, $default = null)
     {
@@ -52,21 +53,21 @@ class Account extends Fluent implements Accountable
     }
 
     /**
-     * Get the accountable id.
+     * Gets the accountable id.
      *
-     * @return int
+     * @return string|int
      */
-    public function getId()
+    public function getId(): string|int
     {
         return $this->attributes['id'];
     }
 
     /**
-     * Get the accountable name.
+     * Gets the accountable name.
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->attributes['name'] ?? $this->attributes['id'];
     }

--- a/src/Fluent/Provider.php
+++ b/src/Fluent/Provider.php
@@ -15,7 +15,7 @@ class Provider extends Fluent implements Providable
      */
     protected ServiceConfig $serviceConfig;
 
-    public function __construct(ServiceConfig $serviceConfig, $id)
+    public function __construct(ServiceConfig $serviceConfig, string|int $id)
     {
         $this->serviceConfig = $serviceConfig;
 
@@ -26,11 +26,11 @@ class Provider extends Fluent implements Providable
     }
 
     /**
-     * Get an attribute from the fluent instance using "dot" notation.
+     * Gets an attribute from the fluent instance using "dot" notation.
      *
      * @param  string  $key
-     * @param  string|int|mixed|null $default
-     * @return string|int|mixed|null
+     * @param  mixed $default
+     * @return mixed
      */
     public function get($key, $default = null)
     {
@@ -38,7 +38,7 @@ class Provider extends Fluent implements Providable
     }
 
     /**
-     * Set an attribute to the fluent instance using "dot" notation.
+     * Sets an attribute to the fluent instance using "dot" notation.
      *
      * @param string $key
      * @param mixed $value
@@ -52,21 +52,21 @@ class Provider extends Fluent implements Providable
     }
 
     /**
-     * Get the providable id.
+     * Gets the providable id.
      *
-     * @return int
+     * @return string|int
      */
-    public function getId()
+    public function getId(): string|int
     {
         return $this->attributes['id'];
     }
 
     /**
-     * Get the providable name.
+     * Gets the providable name.
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->attributes['name'] ?? $this->attributes['id'];
     }

--- a/src/Models/Account.php
+++ b/src/Models/Account.php
@@ -18,14 +18,14 @@ class Account extends Model implements Accountable
      *
      * @var bool
      */
-    public bool $incrementing = false;
+    public $incrementing = false;
 
     /**
      * The attributes that aren't mass assignable.
      *
      * @var array<string>
      */
-    protected array $guarded = [];
+    protected $guarded = [];
 
     /**
      * The service config.

--- a/src/Models/Account.php
+++ b/src/Models/Account.php
@@ -3,6 +3,7 @@
 namespace Payavel\Orchestration\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Str;
 use Payavel\Orchestration\Contracts\Accountable;
 use Payavel\Orchestration\ServiceConfig;
@@ -17,14 +18,14 @@ class Account extends Model implements Accountable
      *
      * @var bool
      */
-    public $incrementing = false;
+    public bool $incrementing = false;
 
     /**
      * The attributes that aren't mass assignable.
      *
-     * @var string[]|bool
+     * @var array<string>
      */
-    protected $guarded = [];
+    protected array $guarded = [];
 
     /**
      * The service config.
@@ -34,47 +35,47 @@ class Account extends Model implements Accountable
     protected ServiceConfig $serviceConfig;
 
     /**
-     * Get the accountable id.
+     * Gets the accountable id.
      *
      * @return string|int
      */
-    public function getId()
+    public function getId(): string|int
     {
         return $this->id;
     }
 
     /**
-     * Get the accountable name.
+     * Gets the accountable name.
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name ?? $this->id;
     }
 
     /**
-     * Get the account's related providers.
+     * Gets the account's related providers.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
-    public function providers()
+    public function providers(): BelongsToMany
     {
         return $this->belongsToMany($this->getProviderModelClass(), 'account_provider', 'account_id', 'provider_id')->withTimestamps();
     }
 
     /**
-     * Get the provider model class relative to the account.
+     * Gets the provider model class relative to the account.
      *
      * @return string
      */
-    protected function getProviderModelClass()
+    protected function getProviderModelClass(): string
     {
-        if(!isset($this->providerModelClass)) {
+        if (!isset($this->providerModelClass)) {
             $this->providerModelClass = $this->guessProviderModelClass();
         }
 
-        if(!isset($this->serviceConfig)) {
+        if (!isset($this->serviceConfig)) {
             $this->serviceConfig = ServiceConfig::find($this->service_id);
         }
 
@@ -82,11 +83,11 @@ class Account extends Model implements Accountable
     }
 
     /**
-     * Guess the provider model class name by convention.
+     * Guesses the provider model class name by convention.
      *
      * @return string
      */
-    protected function guessProviderModelClass()
+    protected function guessProviderModelClass(): string
     {
         $parentClass = get_class($this);
 

--- a/src/Models/Provider.php
+++ b/src/Models/Provider.php
@@ -18,14 +18,14 @@ class Provider extends Model implements Providable
      *
      * @var bool
      */
-    public bool $incrementing = false;
+    public $incrementing = false;
 
     /**
      * The attributes that aren't mass assignable.
      *
      * @var array<string>
      */
-    protected array $guarded = [];
+    protected $guarded = [];
 
     /**
      * The service config.

--- a/src/Models/Provider.php
+++ b/src/Models/Provider.php
@@ -3,6 +3,7 @@
 namespace Payavel\Orchestration\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Str;
 use Payavel\Orchestration\Contracts\Providable;
 use Payavel\Orchestration\ServiceConfig;
@@ -17,14 +18,14 @@ class Provider extends Model implements Providable
      *
      * @var bool
      */
-    public $incrementing = false;
+    public bool $incrementing = false;
 
     /**
      * The attributes that aren't mass assignable.
      *
-     * @var string[]|bool
+     * @var array<string>
      */
-    protected $guarded = [];
+    protected array $guarded = [];
 
     /**
      * The service config.
@@ -34,43 +35,43 @@ class Provider extends Model implements Providable
     protected ServiceConfig $serviceConfig;
 
     /**
-     * Get the providable id.
+     * Gets the providable id.
      *
      * @return string|int
      */
-    public function getId()
+    public function getId(): string|int
     {
         return $this->id;
     }
 
     /**
-     * Get the providable name.
+     * Gets the providable name.
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name ?? $this->id;
     }
 
     /**
-     * Get the provider's related accounts.
+     * Gets the provider's related accounts.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
-    public function accounts()
+    public function accounts(): BelongsToMany
     {
         return $this->belongsToMany($this->getAccountModelClass(), 'account_provider', 'provider_id', 'account_id')->withTimestamps();
     }
 
     /**
-     * Get the account model class relative to the provider.
+     * Gets the account model class relative to the provider.
      *
      * @return string
      */
-    protected function getAccountModelClass()
+    protected function getAccountModelClass(): string
     {
-        if(!isset($this->accountModelClass)) {
+        if (!isset($this->accountModelClass)) {
             $this->accountModelClass = $this->guessAccountModelClass();
         }
 
@@ -83,11 +84,11 @@ class Provider extends Model implements Providable
 
 
     /**
-     * Guess the account model class name by convention.
+     * Guesses the account model class name by convention.
      *
      * @return string
      */
-    protected function guessAccountModelClass()
+    protected function guessAccountModelClass(): string
     {
         $parentClass = get_class($this);
 

--- a/src/OrchestrationServiceProvider.php
+++ b/src/OrchestrationServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Payavel\Orchestration;
 
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\ServiceProvider;
 use Payavel\Orchestration\Console\Commands\OrchestrateService;
 use Payavel\Orchestration\Console\Commands\OrchestrateProvider;
@@ -12,7 +13,12 @@ class OrchestrationServiceProvider extends ServiceProvider
 {
     use MergesConfigRecursively;
 
-    public function boot()
+    /**
+     * Boots the service provider.
+     *
+     * @return void
+     */
+    public function boot(): void
     {
         if (! $this->app->runningInConsole()) {
             return;
@@ -23,7 +29,12 @@ class OrchestrationServiceProvider extends ServiceProvider
         $this->registerCommands();
     }
 
-    public function register()
+    /**
+     * Registers the service provider's dependencies.
+     *
+     * @return void
+     */
+    public function register(): void
     {
         $this->recursivelyMergeConfigFrom(
             __DIR__.'/../config/orchestration.php',
@@ -31,14 +42,24 @@ class OrchestrationServiceProvider extends ServiceProvider
         );
     }
 
-    protected function registerPublishableAssets()
+    /**
+     * Registers the service provider's publishable assets.
+     *
+     * @return void
+     */
+    protected function registerPublishableAssets(): void
     {
         $this->publishes([
             __DIR__.'/../database/migrations/2024_01_01_000001_create_base_orchestration_tables.php' => database_path('migrations/2024_01_01_000001_create_base_orchestration_tables.php'),
         ], ['payavel', 'payavel-orchestration', 'payavel-migrations', 'payavel-orchestration-migrations']);
     }
 
-    protected function registerCommands()
+    /**
+     * Registers the service provider's commands.
+     *
+     * @return void
+     */
+    protected function registerCommands(): void
     {
         $this->commands([
             OrchestrateService::class,

--- a/src/Service.php
+++ b/src/Service.php
@@ -3,6 +3,8 @@
 namespace Payavel\Orchestration;
 
 use Exception;
+use Payavel\Orchestration\Contracts\Accountable;
+use Payavel\Orchestration\Contracts\Providable;
 use Payavel\Orchestration\ServiceConfig;
 use Payavel\Orchestration\Traits\SimulatesAttributes;
 
@@ -15,35 +17,35 @@ class Service
      *
      * @var \Payavel\Orchestration\ServiceConfig
      */
-    protected $config;
+    protected ServiceConfig $config;
 
     /**
      * The service driver that will handle provider/account gateway resolutions.
      *
      * @var \Payavel\Orchestration\ServiceDriver
      */
-    protected $driver;
+    protected ServiceDriver $driver;
 
     /**
      * The configured provider.
      *
      * @var \Payavel\Orchestration\Contracts\Providable
      */
-    protected $provider;
+    protected ?Providable $provider;
 
     /**
      * The configured account.
      *
      * @var \Payavel\Orchestration\Contracts\Accountable
      */
-    protected $account;
+    protected ?Accountable $account;
 
     /**
      * The gateway class where requests will be executed.
      *
-     * @var \Payavel\Orchestration\ServiceRequest
+     * @var \Payavel\Orchestration\ServiceRequest|null
      */
-    protected $gateway;
+    protected ?ServiceRequest $gateway;
 
     /**
      * Sets the service config and the driver for it.
@@ -53,7 +55,7 @@ class Service
      *
      * @throws Exception
      */
-    public function __construct($serviceConfig)
+    public function __construct(ServiceConfig|string|int $serviceConfig)
     {
         if (! $serviceConfig instanceof ServiceConfig && is_null($serviceConfig = ServiceConfig::find($serviceConfig))) {
             throw new Exception("Service config with id '{$serviceConfig}' was not found.");
@@ -69,12 +71,12 @@ class Service
     }
 
     /**
-     * Fluent provider setter.
+     * Sets the provider fluently.
      *
      * @param \Payavel\Orchestration\Contracts\Providable|string|int $provider
      * @return \Payavel\Orchestration\Service
      */
-    public function provider($provider)
+    public function provider(Providable|string|int $provider): static
     {
         $this->setProvider($provider);
 
@@ -82,11 +84,11 @@ class Service
     }
 
     /**
-     * Get the current provider.
+     * Gets the current provider.
      *
      * @return \Payavel\Orchestration\Contracts\Providable
      */
-    public function getProvider()
+    public function getProvider(): Providable
     {
         if (! isset($this->provider)) {
             $this->setProvider($this->getDefaultProvider());
@@ -96,14 +98,14 @@ class Service
     }
 
     /**
-     * Set the provider.
+     * Sets the provider.
      *
      * @param \Payavel\Orchestration\Contracts\Providable|string|int $provider
      * @return void
      *
      * @throws Exception
      */
-    public function setProvider($provider)
+    public function setProvider(Providable|string|int $provider): void
     {
         if (is_null($provider = $this->driver->resolveProvider($provider))) {
             throw new Exception('Invalid provider.');
@@ -115,22 +117,22 @@ class Service
     }
 
     /**
-     * Get the default service provider.
+     * Gets the default service provider.
      *
      * @return string|int|\Payavel\Orchestration\Contracts\Providable
      */
-    public function getDefaultProvider()
+    public function getDefaultProvider(): string|int|Providable
     {
         return $this->driver->getDefaultProvider($this->account);
     }
 
     /**
-     * Fluent account setter.
+     * Sets the account fluently.
      *
      * @param \Payavel\Orchestration\Contracts\Accountable|string|int $account
      * @return \Payavel\Orchestration\Service
      */
-    public function account($account)
+    public function account(Accountable|string|int $account): static
     {
         $this->setAccount($account);
 
@@ -138,11 +140,11 @@ class Service
     }
 
     /**
-     * Get the current account.
+     * Gets the current account.
      *
      * @return \Payavel\Orchestration\Contracts\Accountable
      */
-    public function getAccount()
+    public function getAccount(): Accountable
     {
         if (! isset($this->account)) {
             $this->setAccount($this->getDefaultAccount());
@@ -152,14 +154,14 @@ class Service
     }
 
     /**
-     * Set the specified account.
+     * Sets the specified account.
      *
      * @param \Payavel\Orchestration\Contracts\Accountable|string|int $account
      * @return void
      *
      * @throws Exception
      */
-    public function setAccount($account)
+    public function setAccount(Accountable|string|int $account): void
     {
         if (is_null($account = $this->driver->resolveAccount($account))) {
             throw new Exception('Invalid account.');
@@ -171,21 +173,21 @@ class Service
     }
 
     /**
-     * Get the default account.
+     * Gets the default account.
      *
      * @return string|int|\Payavel\Orchestration\Contracts\Accountable
      */
-    public function getDefaultAccount()
+    public function getDefaultAccount(): string|int|Accountable
     {
         return $this->driver->getDefaultAccount($this->provider);
     }
 
     /**
-     * Get the service's gateway.
+     * Gets the service's gateway.
      *
      * @return \Payavel\Orchestration\ServiceRequest
      */
-    protected function getGateway()
+    protected function getGateway(): ServiceRequest
     {
         if (! isset($this->gateway)) {
             $this->setGateway();
@@ -195,11 +197,11 @@ class Service
     }
 
     /**
-     * Resolve a new instance of the service's gateway.
+     * Resolves a new instance of the service's gateway.
      *
      * @return void
      */
-    protected function setGateway()
+    protected function setGateway(): void
     {
         $provider = $this->getProvider();
         $account = $this->getAccount();
@@ -208,11 +210,11 @@ class Service
     }
 
     /**
-     * Reset the service to its defaults.
+     * Resets the service to its defaults.
      *
      * @return void
      */
-    public function reset()
+    public function reset(): void
     {
         $this->driver->refresh();
 
@@ -223,9 +225,11 @@ class Service
      * @param string $method
      * @param array $params
      *
+     * @return \Payavel\Orchestration\ServiceResponse|mixed
+     *
      * @throws \BadMethodCallException
      */
-    public function __call($method, $params)
+    public function __call(string $method, array $params = []): mixed
     {
         return $this->getGateway()->request($method, $params);
     }

--- a/src/Service.php
+++ b/src/Service.php
@@ -31,21 +31,21 @@ class Service
      *
      * @var \Payavel\Orchestration\Contracts\Providable
      */
-    protected ?Providable $provider;
+    protected ?Providable $provider = null;
 
     /**
      * The configured account.
      *
      * @var \Payavel\Orchestration\Contracts\Accountable
      */
-    protected ?Accountable $account;
+    protected ?Accountable $account = null;
 
     /**
      * The gateway class where requests will be executed.
      *
      * @var \Payavel\Orchestration\ServiceRequest|null
      */
-    protected ?ServiceRequest $gateway;
+    protected ?ServiceRequest $gateway = null;
 
     /**
      * Sets the service config and the driver for it.

--- a/src/ServiceConfig.php
+++ b/src/ServiceConfig.php
@@ -14,9 +14,9 @@ class ServiceConfig
     /**
      * The service id.
      *
-     * @var string
+     * @var string|int
      */
-    protected string $id;
+    protected string|int $id;
 
     /**
      * The service config path.
@@ -25,7 +25,7 @@ class ServiceConfig
      */
     protected string $config;
 
-    public function __construct($id)
+    public function __construct(string|int $id)
     {
         $this->id = $id;
 
@@ -37,66 +37,66 @@ class ServiceConfig
     }
 
     /**
-     * Get an attribute from the fluent instance using "dot" notation.
+     * Gets an attribute from the fluent instance using "dot" notation.
      *
-     * @param  string  $key
-     * @param  string|int|mixed|null $default
-     * @return string|int|mixed|null
+     * @param string $key
+     * @param mixed $default
+     * @return mixed
      */
-    public function get($key, $default = null)
+    public function get(string $key, mixed $default = null): mixed
     {
         return Config::get("{$this->config}.{$key}", fn () => Config::get('orchestration.'.$key, $default));
     }
 
     /**
-     * Set an attribute to the fluent instance using "dot" notation.
+     * Sets an attribute to the fluent instance using "dot" notation.
      *
      * @param string $key
      * @param mixed $value
      * @return void
      */
-    public function set($key, $value)
+    public function set(string $key, mixed $value): void
     {
         Config::set("{$this->config}.{$key}", $value);
     }
 
     /**
-     * Get the service id.
+     * Gets the service id.
      *
      * @return string|int
      */
-    public function getId()
+    public function getId(): string|int
     {
         return $this->id;
     }
 
     /**
-     * Get the service name.
+     * Gets the service name.
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->get('name', $this->id);
     }
 
     /**
-     * Get all of the orchestration service ids.
+     * Gets all of the orchestration service ids.
      *
      * @return \Illuminate\Support\Collection
      */
-    public static function all()
+    public static function all(): Collection
     {
         return Collection::make(Config::get('orchestration.services', []))->keys()->map(fn ($id) => new static($id));
     }
 
     /**
-     * Get the service's config by it's id.
+     * Gets the service's config by it's id.
      *
      * @param string|int $id
      * @return static|null
      */
-    public static function find($id)
+    public static function find(string|int $id): ?static
     {
         try {
             return new static($id);

--- a/src/ServiceDriver.php
+++ b/src/ServiceDriver.php
@@ -32,54 +32,54 @@ abstract class ServiceDriver
      *
      * @return void
      */
-    public function refresh()
+    public function refresh(): void
     {
         //
     }
 
     /**
-     * Resolve the providable instance.
+     * Resolves the providable instance.
      *
      * @param \Payavel\Orchestration\Contracts\Providable|string|int $provider
      * @return \Payavel\Orchestration\Contracts\Providable|null
      */
-    abstract public function resolveProvider($provider);
+    abstract public function resolveProvider(Providable|string|int $provider): ?Providable;
 
     /**
-     * Get the default providable identifier.
+     * Gets the default providable identifier.
      *
      * @param \Payavel\Orchestration\Contracts\Accountable|null $account
      * @return string|int
      */
-    abstract public function getDefaultProvider(?Accountable $account = null);
+    abstract public function getDefaultProvider(?Accountable $account = null): string|int;
 
     /**
-     * Resolve the accountable instance.
+     * Resolves the accountable instance.
      *
      * @param \Payavel\Orchestration\Contracts\Accountable|string|int $account
      * @return \Payavel\Orchestration\Contracts\Accountable|null
      */
-    abstract public function resolveAccount($account);
+    abstract public function resolveAccount(Accountable|string|int $account): ?Accountable;
 
     /**
-     * Get the default accountable identifier.
+     * Gets the default accountable identifier.
      *
      * @param \Payavel\Orchestration\Contracts\Providable|null $provider
      * @return string|int
      */
-    abstract public function getDefaultAccount(?Providable $provider = null);
+    abstract public function getDefaultAccount(?Providable $provider = null): string|int;
 
     /**
-     * Resolve the gateway.
+     * Resolves the gateway.
      *
      * @param \Payavel\Orchestration\Contracts\Providable $provider
      * @param \Payavel\Orchestration\Contracts\Accountable $account
      * @return \Payavel\Orchestration\ServiceRequest
      */
-    abstract public function resolveGateway(Providable $provider, Accountable $account);
+    abstract public function resolveGateway(Providable $provider, Accountable $account): ServiceRequest;
 
     /**
-     * Generate the service skeleton based on the current driver.
+     * Generates the service skeleton based on the current driver.
      *
      * @param \Payavel\Orchestration\ServiceConfig $serviceConfig
      * @param \Illuminate\Support\Collection $providers
@@ -87,7 +87,7 @@ abstract class ServiceDriver
      * @param array $defaults
      * @return void
      */
-    public static function generateService(ServiceConfig $serviceConfig, Collection $providers, Collection $accounts, array $defaults)
+    public static function generateService(ServiceConfig $serviceConfig, Collection $providers, Collection $accounts, array $defaults): void
     {
         //
     }

--- a/src/ServiceDriver.php
+++ b/src/ServiceDriver.php
@@ -51,7 +51,7 @@ abstract class ServiceDriver
      * @param \Payavel\Orchestration\Contracts\Accountable|null $account
      * @return string|int
      */
-    abstract public function getDefaultProvider(Accountable $account = null);
+    abstract public function getDefaultProvider(?Accountable $account = null);
 
     /**
      * Resolve the accountable instance.
@@ -67,7 +67,7 @@ abstract class ServiceDriver
      * @param \Payavel\Orchestration\Contracts\Providable|null $provider
      * @return string|int
      */
-    abstract public function getDefaultAccount(Providable $provider = null);
+    abstract public function getDefaultAccount(?Providable $provider = null);
 
     /**
      * Resolve the gateway.

--- a/src/ServiceRequest.php
+++ b/src/ServiceRequest.php
@@ -13,26 +13,22 @@ abstract class ServiceRequest
      *
      * @var \Payavel\Orchestration\ServiceResponse
      */
-    protected $serviceResponse;
+    protected ServiceResponse $serviceResponse;
 
     /**
      * The service provider.
      *
      * @var \Payavel\Orchestration\Contracts\Providable
      */
-    protected $provider;
+    protected Providable $provider;
 
     /**
      * The service account.
      *
      * @var \Payavel\Orchestration\Contracts\Accountable
      */
-    protected $account;
+    protected Accountable $account;
 
-    /**
-     * @param  \Payavel\Orchestration\Contracts\Providable $provider
-     * @param  \Payavel\Orchestration\Contracts\Accountable $account
-     */
     public function __construct(Providable $provider, Accountable $account)
     {
         $this->provider = $provider;
@@ -42,26 +38,26 @@ abstract class ServiceRequest
     }
 
     /**
-     * Set up the request.
+     * Sets up the request.
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         //
     }
 
     /**
-     * Make the request.
+     * Makes the request.
      *
      * @param string $method
-     * @param array|null $params
+     * @param array $params
      *
      * @return \Payavel\Orchestration\ServiceResponse|mixed
      *
      * @throws \BadMethodCallException
      */
-    public function request($method, $params)
+    public function request(string $method, array $params = []): mixed
     {
         if (! method_exists($this, $method)) {
             throw new \BadMethodCallException(get_class($this)."::{$method}() not found.");
@@ -77,13 +73,13 @@ abstract class ServiceRequest
     }
 
     /**
-     * Format the response.
+     * Formats the response.
      *
      * @param mixed $rawResponse
      *
      * @return \Payavel\Orchestration\ServiceResponse
      */
-    public function response($rawResponse)
+    public function response(mixed $rawResponse): ServiceResponse
     {
         $serviceResponse = $this->serviceResponse ?? Str::replace('Request', 'Response', get_class($this));
 

--- a/src/ServiceResponse.php
+++ b/src/ServiceResponse.php
@@ -17,61 +17,58 @@ abstract class ServiceResponse
      *
      * @var array
      */
-    protected $successStatuses = [];
+    protected array $successStatuses = [];
 
     /**
-     * Customize the response method names for your requests.
+     * Custom response method names of the requests.
      *
      * @var array
      */
-    protected $responseMethods = [];
+    protected array $responseMethods = [];
 
     /**
      * The provider's raw response.
      *
      * @var mixed
      */
-    protected $rawResponse;
+    protected mixed $rawResponse;
 
     /**
      * Additional data needed to format the response.
      *
      * @var mixed
      */
-    protected $additionalData;
+    protected mixed $additionalData;
 
     /**
      * The request method that returned this response.
      *
      * @var string
      */
-    public $requestMethod;
+    public string $requestMethod;
 
     /**
-     * The provider that the $request was made towards.
+     * The provider that the request was made towards.
      *
      * @var \Payavel\Orchestration\Contracts\Providable
      */
     public $provider;
 
     /**
-     * The account that was used to make the $request.
+     * The account that was used to make the request.
      *
      * @var \Payavel\Orchestration\Contracts\Accountable
      */
-    public $account;
+    public Accountable $account;
 
     /**
      * The expected formatted data based on the $request.
      *
      * @var mixed
      */
-    private $data;
+    private mixed $data;
 
-    /**
-     * @param mixed $rawResponse
-     */
-    public function __construct($rawResponse)
+    public function __construct(mixed $rawResponse)
     {
         $this->rawResponse = $rawResponse;
 
@@ -79,23 +76,23 @@ abstract class ServiceResponse
     }
 
     /**
-     * Set up the response.
+     * Sets up the response.
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         //
     }
 
     /**
-     * Share additional data.
+     * Shares additional data.
      *
      * @param mixed $additionalData
      *
      * @return static
      */
-    public function with($additionalData)
+    public function with(mixed $additionalData): static
     {
         $this->additionalData = $additionalData;
 
@@ -103,15 +100,15 @@ abstract class ServiceResponse
     }
 
     /**
-     * Configure the response based on the request.
+     * Configures the response based on the request.
      *
      * @param string $requestMethod
      * @param \Payavel\Orchestration\Contracts\Providable $provider
      * @param \Payavel\Orchestration\Contracts\Accountable $account
      *
-     * @return static
+     * @return \Payavel\Orchestration\ServiceResponse
      */
-    public function configure(string $requestMethod, Providable $provider, Accountable $account)
+    public function configure(string $requestMethod, Providable $provider, Accountable $account): static
     {
         $this->requestMethod = $requestMethod;
         $this->provider = $provider;
@@ -121,11 +118,11 @@ abstract class ServiceResponse
     }
 
     /**
-     * Get the provider's raw response.
+     * Gets the provider's raw response.
      *
      * @return mixed
      */
-    public function getRawResponse()
+    public function getRawResponse(): mixed
     {
         return $this->rawResponse;
     }
@@ -135,60 +132,60 @@ abstract class ServiceResponse
      *
      * @return mixed
      */
-    public function getRaw()
+    public function getRaw(): mixed
     {
         return $this->getRawResponse();
     }
 
     /**
-     * Verify whether the request should be considered successful.
+     * Verifies whether the request should be considered successful.
      *
      * @return bool
      */
-    public function isSuccessful()
+    public function isSuccessful(): bool
     {
         return in_array($this->getStatusCode(), $this->successStatuses);
     }
 
     /**
-     * Verify whether the request should be considered a failure.
+     * Verifies whether the request should be considered a failure.
      *
      * @return bool
      */
-    public function isNotSuccessful()
+    public function isNotSuccessful(): bool
     {
         return ! $this->isSuccessful();
     }
 
     /**
-     * Determines the status code based on the request's raw response.
+     * Gets the status code based on the request's raw response.
      *
-     * @return int
+     * @return int|string
      */
-    abstract public function getStatusCode();
+    abstract public function getStatusCode(): int|string;
 
     /**
-     * Get a string representation of the response's status.
+     * Gets a string representation of the response's status.
      *
      * @return string|null
      */
-    abstract public function getStatusMessage();
+    abstract public function getStatusMessage(): ?string;
 
     /**
-     * Get a description of the response's status.
+     * Gets a description of the response's status.
      *
      * @return string|null
      */
-    abstract public function getStatusDescription();
+    abstract public function getStatusDescription(): ?string;
 
     /**
-     * Get the formatted details based on the request that was made.
+     * Gets the formatted details based on the request that was made.
      *
-     * @return array|mixed
+     * @return mixed
      *
      * @throws \RuntimeException
      */
-    public function getData()
+    public function getData(): mixed
     {
         if (! isset($this->data)) {
             $this->data = $this->{$this->getResponseMethod()}();
@@ -198,11 +195,11 @@ abstract class ServiceResponse
     }
 
     /**
-     * Get the response method that should be used to get the response's data.
+     * Gets the response method that should be used to get the response's data.
      *
      * @return string
      */
-    protected function getResponseMethod()
+    protected function getResponseMethod(): string
     {
         if (isset($this->requestMethod)) {
             if (
@@ -221,7 +218,7 @@ abstract class ServiceResponse
     }
 
     /**
-     * The generic request response.
+     * Defines the generic request response.
      *
      * @throws \RuntimeException
      */

--- a/src/ServiceResponse.php
+++ b/src/ServiceResponse.php
@@ -38,7 +38,7 @@ abstract class ServiceResponse
      *
      * @var mixed
      */
-    protected mixed $additionalData;
+    protected mixed $additionalData = null;
 
     /**
      * The request method that returned this response.

--- a/src/Traits/AsksQuestions.php
+++ b/src/Traits/AsksQuestions.php
@@ -7,12 +7,12 @@ use function Laravel\Prompts\text;
 trait AsksQuestions
 {
     /**
-     * Ask for the name of the entity (provider, account, etc...) to be added.
+     * Asks for the name of the entity (provider, account, etc...) to be added.
      *
      * @param string $entity
      * @return string
      */
-    protected function askName($entity)
+    protected function askName(string $entity): string
     {
         return text(
             label: "How should the {$this->formatService($entity)} be named?"
@@ -20,13 +20,13 @@ trait AsksQuestions
     }
 
     /**
-     * Ask for the id of the entity (provider, account, etc...) to be added.
+     * Asks for the id of the entity (provider, account, etc...) to be added.
      *
      * @param string $entity
      * @param string $name
      * @return string
      */
-    protected function askId($entity, $name)
+    protected function askId(string $entity, string $name): string
     {
         $id = preg_replace('/[^a-z0-9]+/i', '_', strtolower($name));
 
@@ -39,12 +39,12 @@ trait AsksQuestions
     }
 
     /**
-     * Properly format the service entity.
+     * Properly formats the service entity.
      *
      * @param string $entity
      * @return string
      */
-    private function formatService($entity)
+    private function formatService(string $entity): string
     {
         return ($this->serviceConfig ? ($this->serviceConfig->name.' ') : '').$entity;
     }

--- a/src/Traits/GeneratesFiles.php
+++ b/src/Traits/GeneratesFiles.php
@@ -8,13 +8,13 @@ use Illuminate\Support\Str;
 trait GeneratesFiles
 {
     /**
-     * Get the contents of the file.
+     * Gets the contents of the file.
      *
      * @param string $stub
      * @param array $data
      * @return string
      */
-    protected static function makeFile($stub, $data)
+    protected static function makeFile(string $stub, array $data): string
     {
         $file = file_get_contents($stub);
 
@@ -26,13 +26,13 @@ trait GeneratesFiles
     }
 
     /**
-     * Put the given file in the specified path.
+     * Puts the given file in the specified path.
      *
      * @param string $path
      * @param string $file
      * @return void
      */
-    protected static function putFile($path, $file)
+    protected static function putFile(string $path, string $file): void
     {
         $fileSystem = new Filesystem();
 
@@ -43,13 +43,13 @@ trait GeneratesFiles
     }
 
     /**
-     * Get the most relevant stub file.
+     * Gets the most relevant stub file.
      *
      * @param string $stub
      * @param string|null $service
      * @return string
      */
-    protected static function getStub(string $stub, ?string $service = null)
+    protected static function getStub(string $stub, ?string $service = null): string
     {
         if (
             (

--- a/src/Traits/GeneratesFiles.php
+++ b/src/Traits/GeneratesFiles.php
@@ -49,7 +49,7 @@ trait GeneratesFiles
      * @param string|null $service
      * @return string
      */
-    protected static function getStub($stub, $service = null)
+    protected static function getStub(string $stub, ?string $service = null)
     {
         if (
             (

--- a/src/Traits/HasFactory.php
+++ b/src/Traits/HasFactory.php
@@ -11,11 +11,11 @@ trait HasFactory
     use HasEloquentFactory;
 
     /**
-     * Create a new factory instance for the model.
+     * Creates a new factory instance for the model.
      *
      * @return \Illuminate\Database\Eloquent\Factories\Factory<static>
      */
-    protected static function newFactory()
+    protected static function newFactory(): Factory
     {
         if (! class_exists($factory = Factory::resolveFactoryName(get_called_class()))) {
             $factory =
@@ -33,7 +33,7 @@ trait HasFactory
      *
      * @return string
      */
-    protected static function getFactoryNamespace()
+    protected static function getFactoryNamespace(): string
     {
         return 'Payavel\\Orchestration\\Database\\Factories';
     }

--- a/src/Traits/MergesConfigRecursively.php
+++ b/src/Traits/MergesConfigRecursively.php
@@ -6,7 +6,14 @@ use Illuminate\Contracts\Foundation\CachesConfiguration;
 
 trait MergesConfigRecursively
 {
-    protected function recursivelyMergeConfigFrom($path, $key)
+    /**
+     * Recursively merges config from the given path.
+     *
+     * @param string $path
+     * @param string $key
+     * @return void
+     */
+    protected function recursivelyMergeConfigFrom(string $path, string $key): void
     {
         if (! ($this->app instanceof CachesConfiguration && $this->app->configurationIsCached())) {
             $config = $this->app->make('config');

--- a/src/Traits/OrchestratesService.php
+++ b/src/Traits/OrchestratesService.php
@@ -2,6 +2,8 @@
 
 namespace Payavel\Orchestration\Traits;
 
+use Payavel\Orchestration\Contracts\Accountable;
+use Payavel\Orchestration\Contracts\Providable;
 use Payavel\Orchestration\Service;
 
 trait OrchestratesService
@@ -11,14 +13,14 @@ trait OrchestratesService
      *
      * @param \Payavel\Orchestration\Service
      */
-    private $orchestratedService;
+    private Service $orchestratedService;
 
     /**
-     * Gets the orchestrable service. Also sets it if it hasn't been resolved yet.
+     * Gets the orchestrable service, or sets it if it hasn't been resolved yet.
      *
      * @return \Payavel\Orchestration\Service
      */
-    public function getService()
+    public function getService(): Service
     {
         if (! isset($this->orchestratedService)) {
             $this->orchestratedService = (new Service($this->service_id ?? $this->serviceId))
@@ -34,7 +36,7 @@ trait OrchestratesService
      *
      * @return \Payavel\Orchestration\Contracts\Providable
      */
-    public function getProvider()
+    public function getProvider(): Providable
     {
         return $this->getService()->getProvider();
     }
@@ -44,17 +46,17 @@ trait OrchestratesService
      *
      * @return \Payavel\Orchestration\Contracts\Accountable
      */
-    public function getAccount()
+    public function getAccount(): Accountable
     {
         return $this->getService()->getAccount();
     }
 
     /**
-     * Retrieve the service as a property when applied to a Model.
+     * Retrieves the service as a property when applied to a Model.
      *
      * @return \Payavel\Orchestration\Service
      */
-    protected function getServiceAttribute()
+    protected function getServiceAttribute(): Service
     {
         return $this->getService();
     }

--- a/src/Traits/SimulatesAttributes.php
+++ b/src/Traits/SimulatesAttributes.php
@@ -14,12 +14,12 @@ trait SimulatesAttributes
     protected array $attributes = [];
 
     /**
-     * If a get method exists, it gets executed, otherwise returns a value from the $attributes array.
+     * If a get method exists, it gets executed, otherwise it returns a value from the $attributes array.
      *
-     * @param string $key.
+     * @param string $key
      * @return mixed
      */
-    public function __get($key)
+    public function __get(string $key): mixed
     {
         if (! method_exists(self::class, $method = 'get'.Str::studly($key))) {
             return $this->getAttribute($key);
@@ -29,13 +29,13 @@ trait SimulatesAttributes
     }
 
     /**
-     * If a set method exists, it gets executed, otherwise sets value in the $attributes array.
+     * If a set method exists, it gets executed, otherwise it sets a value in the $attributes array.
      *
      * @param string $key
      * @param mixed $value
      * @return void
      */
-    public function __set($key, $value): void
+    public function __set(string $key, mixed $value): void
     {
         if (! method_exists(self::class, $method = 'set'.Str::studly($key))) {
             $this->setAttribute($key, $value);
@@ -47,12 +47,12 @@ trait SimulatesAttributes
     }
 
     /**
-     * Get an attribute from the $attributes array.
+     * Gets an attribute from the $attributes array.
      *
      * @param string $key
      * @return mixed
      */
-    protected function getAttribute($key)
+    protected function getAttribute(string $key): mixed
     {
         return $this->attributes[$key] ?? null;
     }
@@ -64,7 +64,7 @@ trait SimulatesAttributes
      * @param mixed $value
      * @return void
      */
-    protected function setAttribute($key, $value)
+    protected function setAttribute(string $key, mixed $value): void
     {
         $this->attributes[$key] = $value;
     }

--- a/src/Traits/ThrowsRuntimeException.php
+++ b/src/Traits/ThrowsRuntimeException.php
@@ -13,7 +13,7 @@ trait ThrowsRuntimeException
      *
      * @throws \RuntimeException
      */
-    protected function throwRuntimeException($method)
+    protected function throwRuntimeException(string $method): void
     {
         throw new RuntimeException(get_class($this)."::class does not implement the {$method}() method.");
     }

--- a/stubs/service-request.stub
+++ b/stubs/service-request.stub
@@ -8,11 +8,11 @@ use Payavel\Orchestration\ServiceRequest;
 class {{ Provider }}{{ Service }}Request extends ServiceRequest implements {{ Service }}Requester
 {
     /**
-     * Set up the request.
+     * Sets up the request.
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         //
     }

--- a/stubs/service-response.stub
+++ b/stubs/service-response.stub
@@ -8,41 +8,41 @@ use Payavel\Orchestration\ServiceResponse;
 class {{ Provider }}{{ Service }}Response extends ServiceResponse implements {{ Service }}Responder
 {
     /**
-     * Set up the response.
+     * Sets up the response.
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         //
     }
 
     /**
-     * Determines the status code based on the request's raw response.
+     * Gets the status code based on the request's raw response.
      *
-     * @return int
+     * @return int|string
      */
-    public function getStatusCode()
+    abstract public function getStatusCode(): int|string
     {
         //
     }
 
     /**
-     * Get a string representation of the response's status.
-     *
-     * @return string|null
-     */
-    public function getStatusMessage()
-    {
-        //
-    }
-
-    /**
-     * Get a description of the response's status.
+     * Gets a string representation of the response's status.
      *
      * @return string|null
      */
-    public function getStatusDescription()
+    abstract public function getStatusMessage(): ?string
+    {
+        //
+    }
+
+    /**
+     * Gets a description of the response's status.
+     *
+     * @return string|null
+     */
+    abstract public function getStatusDescription(): ?string
     {
         //
     }

--- a/tests/Contracts/CreatesServiceables.php
+++ b/tests/Contracts/CreatesServiceables.php
@@ -12,27 +12,30 @@ interface CreatesServiceables
      * Creates a service config instance.
      *
      * @param array $data
+     *
      * @return \Payavel\Orchestration\ServiceConfig
      */
-    public function createServiceConfig($data = []);
+    public function createServiceConfig(array $data = []): ServiceConfig;
 
     /**
      * Creates a providable instance.
      *
      * @param \Payavel\Orchestration\ServiceConfig $serviceConfig
      * @param array $data
+     *
      * @return \Payavel\Orchestration\Contracts\Providable
      */
-    public function createProvider(ServiceConfig $serviceConfig, $data = []);
+    public function createProvider(ServiceConfig $serviceConfig, array $data = []): Providable;
 
     /**
      * Creates an accountable instance.
      *
      * @param \Payavel\Orchestration\ServiceConfig $serviceConfig
      * @param array $data
+     *
      * @return \Payavel\Orchestration\Contracts\Accountable
      */
-    public function createAccount(ServiceConfig $serviceConfig, $data = []);
+    public function createAccount(ServiceConfig $serviceConfig, array $data = []): Accountable;
 
     /**
      * Links a accountable instance to a providable one.
@@ -40,9 +43,10 @@ interface CreatesServiceables
      * @param Accountable $account
      * @param Providable $provider
      * @param array $data
+     *
      * @return void
      */
-    public function linkAccountToProvider(Accountable $account, Providable $provider, $data = []);
+    public function linkAccountToProvider(Accountable $account, Providable $provider, array $data = []): void;
 
     /**
      * Sets the default configuration for a service.
@@ -50,7 +54,8 @@ interface CreatesServiceables
      * @param \Payavel\Orchestration\ServiceConfig $serviceConfig
      * @param Accountable|null $account
      * @param Providable|null $provider
+     *
      * @return void
      */
-    public function setDefaultsForService(ServiceConfig $serviceConfig, ?Accountable $account = null, ?Providable $provider = null);
+    public function setDefaultsForService(ServiceConfig $serviceConfig, ?Accountable $account = null, ?Providable $provider = null): void;
 }

--- a/tests/Contracts/CreatesServiceables.php
+++ b/tests/Contracts/CreatesServiceables.php
@@ -52,5 +52,5 @@ interface CreatesServiceables
      * @param Providable|null $provider
      * @return void
      */
-    public function setDefaultsForService(ServiceConfig $serviceConfig, Accountable $account = null, Providable $provider = null);
+    public function setDefaultsForService(ServiceConfig $serviceConfig, ?Accountable $account = null, ?Providable $provider = null);
 }

--- a/tests/Services/Mock/Contracts/MockRequester.php
+++ b/tests/Services/Mock/Contracts/MockRequester.php
@@ -2,7 +2,16 @@
 
 namespace Payavel\Orchestration\Tests\Services\Mock\Contracts;
 
+use Payavel\Orchestration\ServiceResponse;
+
 interface MockRequester
 {
-    public function getIdentity();
+    /**
+     * Dummy method to assert against.
+     *
+     * @param bool $withAdditionalData
+     *
+     * @return \Payavel\Orchestration\ServiceResponse
+     */
+    public function getIdentity(bool $withAdditionalData = false): ServiceResponse;
 }

--- a/tests/Services/Mock/Contracts/MockRequester.php
+++ b/tests/Services/Mock/Contracts/MockRequester.php
@@ -2,8 +2,6 @@
 
 namespace Payavel\Orchestration\Tests\Services\Mock\Contracts;
 
-use Payavel\Orchestration\ServiceResponse;
-
 interface MockRequester
 {
     /**
@@ -11,7 +9,7 @@ interface MockRequester
      *
      * @param bool $withAdditionalData
      *
-     * @return \Payavel\Orchestration\ServiceResponse
+     * @return \Payavel\Orchestration\ServiceResponse|mixed
      */
-    public function getIdentity(bool $withAdditionalData = false): ServiceResponse;
+    public function getIdentity(bool $withAdditionalData = false): mixed;
 }

--- a/tests/Services/Mock/Contracts/MockResponder.php
+++ b/tests/Services/Mock/Contracts/MockResponder.php
@@ -4,5 +4,10 @@ namespace Payavel\Orchestration\Tests\Services\Mock\Contracts;
 
 interface MockResponder
 {
-    public function getIdentityResponse();
+    /**
+     * Dummy method to assert against.
+     *
+     * @return mixed
+     */
+    public function getIdentityResponse(): mixed;
 }

--- a/tests/Services/Mock/FakeMockRequest.php
+++ b/tests/Services/Mock/FakeMockRequest.php
@@ -3,12 +3,11 @@
 namespace Payavel\Orchestration\Tests\Services\Mock;
 
 use Payavel\Orchestration\ServiceRequest;
-use Payavel\Orchestration\ServiceResponse;
 use Payavel\Orchestration\Tests\Services\Mock\Contracts\MockRequester;
 
 class FakeMockRequest extends ServiceRequest implements MockRequester
 {
-    public function getIdentity(bool $withAdditionalData = false): ServiceResponse
+    public function getIdentity(bool $withAdditionalData = false): mixed
     {
         $response = [];
 

--- a/tests/Services/Mock/FakeMockRequest.php
+++ b/tests/Services/Mock/FakeMockRequest.php
@@ -3,11 +3,12 @@
 namespace Payavel\Orchestration\Tests\Services\Mock;
 
 use Payavel\Orchestration\ServiceRequest;
+use Payavel\Orchestration\ServiceResponse;
 use Payavel\Orchestration\Tests\Services\Mock\Contracts\MockRequester;
 
 class FakeMockRequest extends ServiceRequest implements MockRequester
 {
-    public function getIdentity($withAdditionalData = false)
+    public function getIdentity(bool $withAdditionalData = false): ServiceResponse
     {
         $response = [];
 

--- a/tests/Services/Mock/FakeMockResponse.php
+++ b/tests/Services/Mock/FakeMockResponse.php
@@ -7,31 +7,22 @@ use Payavel\Orchestration\Tests\Services\Mock\Contracts\MockResponder;
 
 class FakeMockResponse extends ServiceResponse implements MockResponder
 {
-    /**
-     * @inheritDoc
-     */
-    public function getStatusCode()
+    public function getStatusCode(): int
     {
         return 200;
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function getStatusMessage()
+    public function getStatusMessage(): string
     {
         return 'Success';
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function getStatusDescription()
+    public function getStatusDescription(): string
     {
         return 'All good for now!';
     }
 
-    public function getIdentityResponse()
+    public function getIdentityResponse(): string
     {
         return 'Fake'.(is_null($this->additionalData) ? '' : ' with '.$this->additionalData);
     }

--- a/tests/Services/Mock/TestMockRequest.php
+++ b/tests/Services/Mock/TestMockRequest.php
@@ -3,12 +3,11 @@
 namespace Payavel\Orchestration\Tests\Services\Mock;
 
 use Payavel\Orchestration\ServiceRequest;
-use Payavel\Orchestration\ServiceResponse;
 use Payavel\Orchestration\Tests\Services\Mock\Contracts\MockRequester;
 
 class TestMockRequest extends ServiceRequest implements MockRequester
 {
-    public function getIdentity(bool $withAdditionalData = false): ServiceResponse
+    public function getIdentity(bool $withAdditionalData = false): mixed
     {
         $response = [];
 

--- a/tests/Services/Mock/TestMockRequest.php
+++ b/tests/Services/Mock/TestMockRequest.php
@@ -3,11 +3,12 @@
 namespace Payavel\Orchestration\Tests\Services\Mock;
 
 use Payavel\Orchestration\ServiceRequest;
+use Payavel\Orchestration\ServiceResponse;
 use Payavel\Orchestration\Tests\Services\Mock\Contracts\MockRequester;
 
 class TestMockRequest extends ServiceRequest implements MockRequester
 {
-    public function getIdentity($withAdditionalData = false)
+    public function getIdentity(bool $withAdditionalData = false): ServiceResponse
     {
         $response = [];
 

--- a/tests/Services/Mock/TestMockResponse.php
+++ b/tests/Services/Mock/TestMockResponse.php
@@ -7,31 +7,22 @@ use Payavel\Orchestration\Tests\Services\Mock\Contracts\MockResponder;
 
 class TestMockResponse extends ServiceResponse implements MockResponder
 {
-    /**
-     * @inheritDoc
-     */
-    public function getStatusCode()
+    public function getStatusCode(): int
     {
         return 200;
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function getStatusMessage()
+    public function getStatusMessage(): string
     {
         return 'Success';
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function getStatusDescription()
+    public function getStatusDescription(): string
     {
         return 'All good for now!';
     }
 
-    public function getIdentityResponse()
+    public function getIdentityResponse(): string
     {
         return 'Real'.(is_null($this->additionalData) ? '' : ' with '.$this->additionalData);
     }

--- a/tests/Traits/AssertsServiceExists.php
+++ b/tests/Traits/AssertsServiceExists.php
@@ -9,7 +9,7 @@ use Payavel\Orchestration\ServiceConfig;
 
 trait AssertsServiceExists
 {
-    protected function configPath(ServiceConfig $serviceConfig)
+    protected function configPath(ServiceConfig $serviceConfig): Fluent
     {
         $service = Str::slug($serviceConfig->id);
 
@@ -19,7 +19,7 @@ trait AssertsServiceExists
         ]);
     }
 
-    protected function contractPath(ServiceConfig $serviceConfig)
+    protected function contractPath(ServiceConfig $serviceConfig): Fluent
     {
         $service = Str::studly($serviceConfig->id);
 
@@ -30,7 +30,7 @@ trait AssertsServiceExists
         ]);
     }
 
-    protected function gatewayPath(ServiceConfig $serviceConfig, ?Providable $provider = null)
+    protected function gatewayPath(ServiceConfig $serviceConfig, ?Providable $provider = null): Fluent
     {
         $service = Str::studly($serviceConfig->id);
         $provider = is_null($provider) ? 'Fake' : Str::studly($provider->getId());
@@ -42,7 +42,7 @@ trait AssertsServiceExists
         ]);
     }
 
-    protected function assertConfigExists(ServiceConfig $serviceConfig)
+    protected function assertConfigExists(ServiceConfig $serviceConfig): void
     {
         $configPath = $this->configPath($serviceConfig);
 
@@ -50,7 +50,7 @@ trait AssertsServiceExists
         $this->assertFileExists(config_path($configPath->service));
     }
 
-    protected function assertContractExists(ServiceConfig $serviceConfig)
+    protected function assertContractExists(ServiceConfig $serviceConfig): void
     {
         $contractPath = $this->contractPath($serviceConfig);
 
@@ -58,7 +58,7 @@ trait AssertsServiceExists
         $this->assertFileExists(app_path($contractPath->responder));
     }
 
-    protected function assertGatewayExists(ServiceConfig $serviceConfig, ?Providable $provider = null)
+    protected function assertGatewayExists(ServiceConfig $serviceConfig, ?Providable $provider = null): void
     {
         $gatewayPath = $this->gatewayPath($serviceConfig, $provider);
 

--- a/tests/Traits/AssertsServiceExists.php
+++ b/tests/Traits/AssertsServiceExists.php
@@ -30,7 +30,7 @@ trait AssertsServiceExists
         ]);
     }
 
-    protected function gatewayPath(ServiceConfig $serviceConfig, Providable $provider = null)
+    protected function gatewayPath(ServiceConfig $serviceConfig, ?Providable $provider = null)
     {
         $service = Str::studly($serviceConfig->id);
         $provider = is_null($provider) ? 'Fake' : Str::studly($provider->getId());
@@ -58,7 +58,7 @@ trait AssertsServiceExists
         $this->assertFileExists(app_path($contractPath->responder));
     }
 
-    protected function assertGatewayExists(ServiceConfig $serviceConfig, Providable $provider = null)
+    protected function assertGatewayExists(ServiceConfig $serviceConfig, ?Providable $provider = null)
     {
         $gatewayPath = $this->gatewayPath($serviceConfig, $provider);
 

--- a/tests/Traits/CreatesConfigServiceables.php
+++ b/tests/Traits/CreatesConfigServiceables.php
@@ -17,9 +17,10 @@ trait CreatesConfigServiceables
      *
      * @param \Payavel\Orchestration\ServiceConfig $serviceConfig
      * @param array $data
+     *
      * @return \Payavel\Orchestration\Contracts\Providable
      */
-    public function createProvider(ServiceConfig $serviceConfig, $data = [])
+    public function createProvider(ServiceConfig $serviceConfig, array $data = []): Providable
     {
         $data['name'] = $data['name'] ?? Str::remove(['\'', ','], $this->faker->unique()->company());
         $data['id'] = $data['id'] ?? preg_replace('/[^a-z0-9]+/i', '_', strtolower($data['name']));
@@ -41,9 +42,10 @@ trait CreatesConfigServiceables
      *
      * @param \Payavel\Orchestration\ServiceConfig $serviceConfig
      * @param array $data
+     *
      * @return \Payavel\Orchestration\Contracts\Accountable
      */
-    public function createAccount(ServiceConfig $serviceConfig, $data = [])
+    public function createAccount(ServiceConfig $serviceConfig, array $data = []): Accountable
     {
         $data['name'] = $data['name'] ?? Str::remove(['\'', ','], $this->faker->unique()->company());
         $data['id'] = $data['id'] ?? preg_replace('/[^a-z0-9]+/i', '_', strtolower($data['name']));
@@ -59,9 +61,10 @@ trait CreatesConfigServiceables
      * @param Accountable $account
      * @param Providable $provider
      * @param array $data
+     *
      * @return void
      */
-    public function linkAccountToProvider(Accountable $account, Providable $provider, $data = [])
+    public function linkAccountToProvider(Accountable $account, Providable $provider, array $data = []): void
     {
         if (!$account instanceof Account) {
             throw new RuntimeException();

--- a/tests/Traits/CreatesDatabaseServiceables.php
+++ b/tests/Traits/CreatesDatabaseServiceables.php
@@ -16,9 +16,10 @@ trait CreatesDatabaseServiceables
      *
      * @param \Payavel\Orchestration\ServiceConfig $serviceConfig
      * @param array $data
+     *
      * @return \Payavel\Orchestration\Contracts\Providable
      */
-    public function createProvider(ServiceConfig $serviceConfig, $data = [])
+    public function createProvider(ServiceConfig $serviceConfig, array $data = []): Providable
     {
         $data['service_id'] = $serviceConfig->id;
 
@@ -30,9 +31,10 @@ trait CreatesDatabaseServiceables
      *
      * @param \Payavel\Orchestration\ServiceConfig $serviceConfig
      * @param array $data
+     *
      * @return \Payavel\Orchestration\Contracts\Accountable
      */
-    public function createAccount(ServiceConfig $serviceConfig, $data = [])
+    public function createAccount(ServiceConfig $serviceConfig, array $data = []): Accountable
     {
         $data['service_id'] = $serviceConfig->id;
 
@@ -45,11 +47,12 @@ trait CreatesDatabaseServiceables
      * @param Accountable $account
      * @param Providable $provider
      * @param array $data
+     *
      * @return void
      */
-    public function linkAccountToProvider(Accountable $account, Providable $provider, $data = [])
+    public function linkAccountToProvider(Accountable $account, Providable $provider, array $data = []): void
     {
-        if(!$account instanceof Account) {
+        if (!$account instanceof Account) {
             throw new RuntimeException();
         }
 

--- a/tests/Traits/CreatesServices.php
+++ b/tests/Traits/CreatesServices.php
@@ -15,9 +15,10 @@ trait CreatesServices
      * Creates a service config instance.
      *
      * @param array $data
+     *
      * @return \Payavel\Orchestration\ServiceConfig
      */
-    public function createServiceConfig($data = [])
+    public function createServiceConfig(array $data = []): ServiceConfig
     {
         $data['name'] = $data['name'] ?? Str::ucfirst($this->faker->unique()->word());
         $data['id'] = $data['id'] ?? Str::slug($data['name'], '_');
@@ -39,9 +40,10 @@ trait CreatesServices
      * @param \Payavel\Orchestration\ServiceConfig $serviceConfig
      * @param Accountable|null $account
      * @param Providable|null $provider
+     *
      * @return void
      */
-    public function setDefaultsForService(ServiceConfig $serviceConfig, ?Accountable $account = null, ?Providable $provider = null)
+    public function setDefaultsForService(ServiceConfig $serviceConfig, ?Accountable $account = null, ?Providable $provider = null): void
     {
         $serviceConfig->set(
             'defaults.account',

--- a/tests/Traits/CreatesServices.php
+++ b/tests/Traits/CreatesServices.php
@@ -41,7 +41,7 @@ trait CreatesServices
      * @param Providable|null $provider
      * @return void
      */
-    public function setDefaultsForService(ServiceConfig $serviceConfig, Accountable $account = null, Providable $provider = null)
+    public function setDefaultsForService(ServiceConfig $serviceConfig, ?Accountable $account = null, ?Providable $provider = null)
     {
         $serviceConfig->set(
             'defaults.account',

--- a/tests/Traits/SetsConfigDriver.php
+++ b/tests/Traits/SetsConfigDriver.php
@@ -11,7 +11,7 @@ trait SetsConfigDriver
      *
      * @return void
      */
-    protected function setDriver()
+    protected function setDriver(): void
     {
         Config::set('orchestration.defaults.driver', 'config');
     }

--- a/tests/Traits/SetsDatabaseDriver.php
+++ b/tests/Traits/SetsDatabaseDriver.php
@@ -12,7 +12,7 @@ trait SetsDatabaseDriver
      *
      * @return void
      */
-    protected function setDriver()
+    protected function setDriver(): void
     {
         Config::set('orchestration.defaults.driver', 'database');
 


### PR DESCRIPTION
### **What does this PR do?** :robot:
1. Fixes PHP 8.4 deprecation notice.
> Implicitly marking parameter as nullable is deprecated, the explicit nullable type must be used instead.
2. Explicitly sets types all around the project.

### **How should this be tested?** :microscope:
Let the tests do their thing.
