### PR TITLE
[3.x] Add getConfig to Accountable

### DIFF
--- a/src/Contracts/Accountable.php
+++ b/src/Contracts/Accountable.php
@@ -17,4 +17,9 @@ interface Accountable
      * @return string
      */
     public function getName(): string;
+
+    /**
+     * Gets the accountable's provider configuration.
+     */
+    public function getConfig(Providable $provider): array;
 }

--- a/src/Fluent/Account.php
+++ b/src/Fluent/Account.php
@@ -4,6 +4,7 @@ namespace Payavel\Orchestration\Fluent;
 
 use Illuminate\Support\Fluent;
 use Payavel\Orchestration\Contracts\Accountable;
+use Payavel\Orchestration\Contracts\Providable;
 use Payavel\Orchestration\ServiceConfig;
 
 class Account extends Fluent implements Accountable
@@ -70,5 +71,16 @@ class Account extends Fluent implements Accountable
     public function getName(): string
     {
         return $this->attributes['name'] ?? $this->attributes['id'];
+    }
+
+    /**
+     * Gets the accountable's provider configuration.
+     *
+     * @param \Payavel\Orchestration\Contracts\Providable $provider
+     * @return array
+     */
+    public function getConfig(Providable $provider): array
+    {
+        return $this->get('providers.'.$provider->getId(), []);
     }
 }

--- a/src/Models/Account.php
+++ b/src/Models/Account.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Str;
 use Payavel\Orchestration\Contracts\Accountable;
+use Payavel\Orchestration\Contracts\Providable;
 use Payavel\Orchestration\ServiceConfig;
 use Payavel\Orchestration\Traits\HasFactory;
 
@@ -52,6 +53,17 @@ class Account extends Model implements Accountable
     public function getName(): string
     {
         return $this->name ?? $this->id;
+    }
+
+    /**
+     * Gets the accountable's provider configuration.
+     *
+     * @param \Payavel\Orchestration\Contracts\Providable $provider
+     * @return array
+     */
+    public function getConfig(Providable $provider): array
+    {
+        return json_decode($this->providers()->where('provider_id', $provider->getId())->first()?->pivot->config ?? '[]', true);
     }
 
     /**

--- a/src/ServiceRequest.php
+++ b/src/ServiceRequest.php
@@ -29,10 +29,16 @@ abstract class ServiceRequest
      */
     protected Accountable $account;
 
+    /**
+     * The accountable's provider configuration.
+     */
+    protected array $config;
+
     public function __construct(Providable $provider, Accountable $account)
     {
         $this->provider = $provider;
         $this->account = $account;
+        $this->config = $this->account->getConfig($this->provider);
 
         $this->setUp();
     }


### PR DESCRIPTION
### **What does this PR do?** :robot:
Currently there is no way to retrieve the account -> provider specific config unless you know which driver is being used, this solves that problem, if you need to find the account's provider specific info, you may get it calling the `->getConfig(Providable $provider)` function on any `Accountable` instance.

### **How should this be tested?** :microscope:
Added phpunit tests to get config using both drivers; config & database.
